### PR TITLE
dropdown menu functionality + parser improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(
   ${PROJECT_SOURCE_DIR}/tabs/profiles.cc
   ${PROJECT_SOURCE_DIR}/tabs/processes.cc
   ${PROJECT_SOURCE_DIR}/tabs/logs.cc
+  ${PROJECT_SOURCE_DIR}/tabs/parser.cc
 )
 
 set(PROJECT_RESOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/resources)

--- a/resources/status.glade
+++ b/resources/status.glade
@@ -2,6 +2,23 @@
 <!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkListStore" id="liststore1">
+    <columns>
+      <!-- column-name Text -->
+      <column type="gchararray"/>
+    </columns>
+    <data>
+      <row>
+        <col id="0" translatable="yes">Enforce</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Complain</col>
+      </row>
+      <row>
+        <col id="0" translatable="yes">Unconfine</col>
+      </row>
+    </data>
+  </object>
   <object class="GtkBox" id="s_box">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -38,22 +55,26 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
-          <object class="GtkComboBox" id="s_status_selection">
+          <object class="GtkComboBoxText" id="s_status_selection">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="tooltip_text" translatable="yes">Chose an action for the currently selected profile</property>
-            <property name="margin_start">10</property>
-            <property name="margin_end">5</property>
+            <property name="margin_left">10</property>
             <property name="has_entry">True</property>
+            <items>
+              <item id="combo_enforce" translatable="yes">Enforce</item>
+              <item id="combo_complain" translatable="yes">Complain</item>
+              <item id="combo_unconfine" translatable="yes">Disable</item>
+            </items>
             <child internal-child="entry">
               <object class="GtkEntry">
                 <property name="can_focus">False</property>
+                <property name="text" translatable="yes">Enforce</property>
               </object>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
+            <property name="fill">True</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -69,7 +90,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
         <child>
@@ -80,7 +101,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
         <child>
@@ -96,7 +117,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>

--- a/resources/status.glade
+++ b/resources/status.glade
@@ -89,9 +89,9 @@
             <property name="can_focus">False</property>
             <property name="margin_start">15</property>
             <property name="margin_end">5</property>
-            <property name="label" translatable="yes">label</property>
-            <property name="ellipsize">end</property>
-            <property name="single_line_mode">True</property>
+            <property name="label" translatable="yes">...</property>
+            <property name="wrap">True</property>
+            <property name="selectable">True</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/resources/status.glade
+++ b/resources/status.glade
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkBox" id="s_box">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="hexpand">True</property>
     <property name="vexpand">True</property>
     <property name="orientation">vertical</property>
     <child>
       <object class="GtkScrolledWindow" id="s_win">
         <property name="visible">True</property>
-        <property name="can-focus">True</property>
+        <property name="can_focus">True</property>
         <property name="hexpand">True</property>
         <property name="vexpand">True</property>
-        <property name="shadow-type">in</property>
+        <property name="shadow_type">in</property>
         <child>
           <object class="GtkTreeView" id="s_view">
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
+            <property name="can_focus">True</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
             <child internal-child="selection">
-              <object class="GtkTreeSelection"/>
+              <object class="GtkTreeSelection" id="s_row"/>
             </child>
           </object>
         </child>
@@ -36,18 +36,18 @@
     <child>
       <object class="GtkBox" id="s_selection_box">
         <property name="visible">True</property>
-        <property name="can-focus">False</property>
+        <property name="can_focus">False</property>
         <child>
           <object class="GtkComboBox" id="s_status_selection">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Chose an action for the currently selected profile</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">5</property>
-            <property name="has-entry">True</property>
+            <property name="can_focus">False</property>
+            <property name="tooltip_text" translatable="yes">Chose an action for the currently selected profile</property>
+            <property name="margin_start">10</property>
+            <property name="margin_end">5</property>
+            <property name="has_entry">True</property>
             <child internal-child="entry">
               <object class="GtkEntry">
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
               </object>
             </child>
           </object>
@@ -61,10 +61,10 @@
           <object class="GtkButton" id="s_apply_button">
             <property name="label" translatable="yes">Apply</property>
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="margin-start">5</property>
-            <property name="margin-end">10</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <property name="margin_start">5</property>
+            <property name="margin_end">10</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -75,7 +75,7 @@
         <child>
           <object class="GtkSpinner" id="s_spinner">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -86,12 +86,12 @@
         <child>
           <object class="GtkLabel" id="s_apply_info_text">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-start">15</property>
-            <property name="margin-end">5</property>
+            <property name="can_focus">False</property>
+            <property name="margin_start">15</property>
+            <property name="margin_end">5</property>
             <property name="label" translatable="yes">label</property>
             <property name="ellipsize">end</property>
-            <property name="single-line-mode">True</property>
+            <property name="single_line_mode">True</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -110,17 +110,17 @@
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can-focus">False</property>
+        <property name="can_focus">False</property>
         <property name="valign">center</property>
-        <property name="margin-start">10</property>
-        <property name="margin-end">10</property>
-        <property name="margin-top">5</property>
+        <property name="margin_start">10</property>
+        <property name="margin_end">10</property>
+        <property name="margin_top">5</property>
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">5</property>
+            <property name="can_focus">False</property>
+            <property name="margin_start">10</property>
+            <property name="margin_end">5</property>
             <property name="label" translatable="yes">Find:</property>
           </object>
           <packing>
@@ -132,7 +132,7 @@
         <child>
           <object class="GtkLabel" id="s_found_label">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -144,15 +144,15 @@
           <object class="GtkCheckButton" id="s_whole_word">
             <property name="label" translatable="yes">Whole Word</property>
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="margin-end">10</property>
-            <property name="draw-indicator">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="margin_end">10</property>
+            <property name="draw_indicator">True</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack-type">end</property>
+            <property name="pack_type">end</property>
             <property name="position">2</property>
           </packing>
         </child>
@@ -160,14 +160,14 @@
           <object class="GtkCheckButton" id="s_match_case">
             <property name="label" translatable="yes">Match Case</property>
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="draw-indicator">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="draw_indicator">True</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack-type">end</property>
+            <property name="pack_type">end</property>
             <property name="position">3</property>
           </packing>
         </child>
@@ -175,14 +175,14 @@
           <object class="GtkCheckButton" id="s_use_regex">
             <property name="label" translatable="yes">Use Regex</property>
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="draw-indicator">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="draw_indicator">True</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack-type">end</property>
+            <property name="pack_type">end</property>
             <property name="position">4</property>
           </packing>
         </child>
@@ -196,14 +196,14 @@
     <child>
       <object class="GtkSearchEntry" id="s_search">
         <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="margin-start">10</property>
-        <property name="margin-end">10</property>
-        <property name="margin-top">5</property>
-        <property name="margin-bottom">5</property>
-        <property name="primary-icon-name">edit-find-symbolic</property>
-        <property name="primary-icon-activatable">False</property>
-        <property name="primary-icon-sensitive">False</property>
+        <property name="can_focus">True</property>
+        <property name="margin_start">10</property>
+        <property name="margin_end">10</property>
+        <property name="margin_top">5</property>
+        <property name="margin_bottom">5</property>
+        <property name="primary_icon_name">edit-find-symbolic</property>
+        <property name="primary_icon_activatable">False</property>
+        <property name="primary_icon_sensitive">False</property>
       </object>
       <packing>
         <property name="expand">False</property>

--- a/src/main.cc
+++ b/src/main.cc
@@ -17,6 +17,8 @@ void register_resource_bundle(){
 
 int main()
 {
+  std::string foo = Parser::get_perms("usr.bin.firefox");
+
   auto app = Gtk::Application::create("com.github.jack-ullery");
   register_resource_bundle();
 

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -5,6 +5,7 @@
 #include "tabs/processes.h"
 #include "tabs/profiles.h"
 #include "tabs/status.h"
+#include "tabs/parser.h"
 
 #include <gtkmm/applicationwindow.h>
 #include <gtkmm/box.h>

--- a/src/tabs/parser.cc
+++ b/src/tabs/parser.cc
@@ -1,0 +1,99 @@
+#include "parser.h"
+
+const std::string WHITESPACE = " \n\r\t\f\v";
+
+// removes leading whitespace as we're reading a formatted source file
+std::string Parser::ltrim(const std::string &s)
+{
+    size_t start = s.find_first_not_of(WHITESPACE);
+    return (start == std::string::npos) ? "" : s.substr(start);
+}
+
+std::string Parser::get_perms(std::string filename) {
+	std::ifstream fp(filename);
+	if (!fp) {
+		std::cerr << "cannot open profile for parsing\n";
+		return "ERROR";
+  }
+
+	// strings for holding tempory file input tokens
+	std::string line;
+	std::string token;
+	std::string path;
+	std::string flags;
+
+	// strings containing the rules/permissions we need to eventually return to be parsed my caller
+	std::string allow_str;
+	std::string deny_str;
+	std::string audit_str;
+	std::string owner_str;
+
+	// move file pointer to first '{' character
+	std::getline(fp, line, '{'); 
+
+	// scan every line into `line` string and check if it's a path to a resource/program with 
+	// access mode flags and if it is then append it to the return string
+	while (std::getline(fp, line, '\n')) {
+		// remove leading whitespace such as indentation
+		line = Parser::ltrim(line);
+
+		if (line.size() <= 0) continue;
+		if (line.at(0) == '#') continue;
+		if (line.at(0) == '}') {
+			// we hit a closing brace, no paths can exist between these braces so skip to the next block
+			// WARNING: this assumes that every closing brace is on it's own new line (seems to be the case so far)
+			std::getline(fp, line, '{');
+			continue;
+		}
+		if (line.at(0) == '/') {
+			// we have our path to the resource/program with no qualifier (i.e. default 'allow')
+			// append to the string holding all rules with the allow qualifier
+			std::istringstream is(line); // so we can use getline as a tokenizer
+			std::getline(is, path, ' ');
+			std::getline(is, flags, ',');
+			allow_str += "path: " + path + "\tmode: " + Parser::ltrim(flags) + '\n';
+			// left in a seperate if statement for any additions that may need to be made later
+			// that would differentiate these from domain sockets that start with @	
+		} else if (line.at(0) == '@') {
+			// we have a UNIX domain socket which is also a path with no qualifier (i.e. default 'allow') 
+			// append to the string holding all rules with the allow qualifier
+			std::istringstream is(line); // so we can use getline as a tokenizer
+			std::getline(is, path, ' ');
+			std::getline(is, flags, ',');
+			allow_str += "path: " + path + "\tmode: " + Parser::ltrim(flags) + '\n';
+			// left in a seperate if statement for any additions that may need to be made later
+			// that would differentiate these from regular paths that start with /
+		} else {
+			// check if the line starts with any of the 4 rule qualifiers (allow, deny, audit, owner)
+			// if it does, append it to the corresponding string
+			std::istringstream is(line); // so we can use getline as a tokenizer
+			std::getline(is, token, ' ');
+			if (token == "deny") {
+				std::getline(is, path, ' ');
+				std::getline(is, flags, ',');
+				deny_str += "path: " + path + "\tmode: " + Parser::ltrim(flags) + '\n';
+			} else if (token == "audit") {
+				std::getline(is, path, ' ');
+				std::getline(is, flags, ',');
+				audit_str += "path: " + path + "\tmode: " + Parser::ltrim(flags) + '\n';
+			} else if (token == "owner") {
+				std::getline(is, path, ' ');
+				std::getline(is, flags, ',');
+				owner_str += "path: " + path + "\tmode: " + Parser::ltrim(flags) + '\n';
+			} else if (token == "allow") {
+				// assigned by default but should still check just in case someone explicitly declared it
+				std::getline(is, path, ' ');
+				std::getline(is, flags, ',');
+				allow_str += "path: " + path + "\tmode: " + Parser::ltrim(flags) + '\n';
+			}
+		}
+	}
+
+	// temporary way of grouping for test output, return type can be changed to account for these categories
+	std::cout << "\n\t\t\t\t\t --- Allow --- \n" + allow_str;
+	std::cout << "\n\t\t\t\t\t --- Deny  --- \n" + deny_str;
+	std::cout << "\n\t\t\t\t\t --- Audit --- \n" + audit_str;
+	std::cout << "\n\t\t\t\t\t --- Owner --- \n" + owner_str;
+
+	return allow_str + deny_str + audit_str + owner_str;
+}

--- a/src/tabs/parser.h
+++ b/src/tabs/parser.h
@@ -5,14 +5,20 @@
 #include <sstream>
 #include <fstream>
 #include <string>
+#include <array>
+#include <algorithm>
 
 class Parser {
   public:
     static std::string get_perms(std::string filename);
+  
+  protected:
     static std::string ltrim(const std::string &s);
+    static std::string handle_path(std::istringstream * is);
     
   private:
     Parser() {} // static class, no need to ever create an instance
+    
 };
 
 #endif // TABS_PARSER_H

--- a/src/tabs/parser.h
+++ b/src/tabs/parser.h
@@ -1,0 +1,18 @@
+#ifndef TABS_PARSER_H
+#define TABS_PARSER_H
+
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <string>
+
+class Parser {
+  public:
+    static std::string get_perms(std::string filename);
+    static std::string ltrim(const std::string &s);
+    
+  private:
+    Parser() {} // static class, no need to ever create an instance
+};
+
+#endif // TABS_PARSER_H

--- a/src/tabs/profiles.cc
+++ b/src/tabs/profiles.cc
@@ -28,8 +28,15 @@ void Profiles::refresh(){
 }
 
 void Profiles::change_status(){
-  //s_row = s_view.get_selection();
-  std::cout << "button works\n" << std::endl;
+  const auto view_obj = Status::get_view();
+  const auto row_obj = view_obj->get_selection();
+  const auto iter = row_obj->get_selected();
+  const auto row = *iter;
+  const auto path = col_record->get_row_data(row, 0);
+  const auto status = col_record->get_row_data(row, 1);
+
+  std::cout << "Row activated: ID=" << path.c_str() << ", Name=" << status.c_str() << std::endl;
+  //std::cout << "button works\n" << std::endl;
 }
 
 Profiles::Profiles()

--- a/src/tabs/profiles.cc
+++ b/src/tabs/profiles.cc
@@ -52,6 +52,8 @@ bool Profiles::execute_change(const std::string& profile, const std::string& sta
   if(exit_status != 0){
     std::cout << "Error calling '"<< args[0] <<"'. " << child_error << std::endl;
     child_output = "{\"processes\": {}, \"profiles\": {}";
+  } else {
+    Status::set_apply_label_text(" Changed '" + profile + "' from " + status + " to " + opposite_status.erase(0,3));
   }
 
   return true;
@@ -59,19 +61,23 @@ bool Profiles::execute_change(const std::string& profile, const std::string& sta
 
 void Profiles::change_status(){
   const auto view_obj = Status::get_view();
+  const auto spinner_obj = Status::get_spinner();
+
+  spinner_obj->start();
+
   const auto row_obj = view_obj->get_selection();
   const auto iter = row_obj->get_selected();
   const auto row = *iter;
   const auto path = col_record->get_row_data(row, 0);
   const auto status = col_record->get_row_data(row, 1);
-
-  std::cout << "Row activated: ID=" << path.c_str() << ", Name=" << status.c_str() << std::endl;
   
   if(!execute_change(path, status)) {
     std::cout << "Error changing the status" << std::endl;
   }
 
   refresh();
+
+  spinner_obj->stop();
 }
 
 Profiles::Profiles()

--- a/src/tabs/profiles.cc
+++ b/src/tabs/profiles.cc
@@ -1,6 +1,8 @@
 #include "jsoncpp/json/json.h"
 #include "profiles.h"
 
+#include <giomm.h>
+#include <glibmm.h>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -27,6 +29,34 @@ void Profiles::refresh(){
   Status::set_status_label_text(" " + std::to_string(num_found) + " matching profiles");
 }
 
+bool Profiles::execute_change(const std::string& profile, const std::string& status){
+  std::string opposite_status; //Stores command based on the current status
+  if(status == "enforce"){
+    opposite_status = "aa-complain";
+  }
+  if(status == "complain"){
+    opposite_status = "aa-enforce";
+  }
+
+  //Command to execute to change the correct profile to the opposite status
+  std::vector<std::string> args = {"sudo", opposite_status, profile};
+
+  std::string child_output;
+  std::string child_error;
+  int exit_status = 0;
+
+  //Executed in commandline, copied from status.cc 
+  Glib::spawn_sync("/usr/sbin/", args, Glib::SpawnFlags::SPAWN_DEFAULT, {}, &child_output, &child_error, &exit_status);
+
+
+  if(exit_status != 0){
+    std::cout << "Error calling '"<< args[0] <<"'. " << child_error << std::endl;
+    child_output = "{\"processes\": {}, \"profiles\": {}";
+  }
+
+  return true;
+}
+
 void Profiles::change_status(){
   const auto view_obj = Status::get_view();
   const auto row_obj = view_obj->get_selection();
@@ -36,7 +66,12 @@ void Profiles::change_status(){
   const auto status = col_record->get_row_data(row, 1);
 
   std::cout << "Row activated: ID=" << path.c_str() << ", Name=" << status.c_str() << std::endl;
-  //std::cout << "button works\n" << std::endl;
+  
+  if(!execute_change(path, status)) {
+    std::cout << "Error changing the status" << std::endl;
+  }
+
+  refresh();
 }
 
 Profiles::Profiles()

--- a/src/tabs/profiles.cc
+++ b/src/tabs/profiles.cc
@@ -30,30 +30,36 @@ void Profiles::refresh(){
 }
 
 bool Profiles::execute_change(const std::string& profile, const std::string& status){
-  std::string opposite_status; //Stores command based on the current status
-  if(status == "enforce"){
-    opposite_status = "aa-complain";
-  }
-  if(status == "complain"){
-    opposite_status = "aa-enforce";
+  std::string new_status; // stores console command based on the potential new status
+  std::string selection = Status::get_selection_text(); // gets the active selection in the dropdown menu
+
+  if (selection == "Enforce" && status != "enforce") {
+    new_status = "aa-enforce";
+  } else if (selection == "Complain" && status != "complain") {
+    new_status = "aa-complain";
+  } else if (selection == "Disable" && status != "disabled") {
+    new_status = "aa-disable";
+  } else {
+    selection[0] = tolower(selection[0]); // for  a e s t h e t i c s 
+    Status::set_apply_label_text("'" + profile + "' already set to " + selection + ".");
+    return true;
   }
 
-  //Command to execute to change the correct profile to the opposite status
-  std::vector<std::string> args = {"sudo", opposite_status, profile};
+  // command to change the profile to the provided status
+  std::vector<std::string> args = {"sudo", new_status, profile};
 
   std::string child_output;
   std::string child_error;
   int exit_status = 0;
 
-  //Executed in commandline, copied from status.cc 
+  // executed in commandline, copied from status.cc 
   Glib::spawn_sync("/usr/sbin/", args, Glib::SpawnFlags::SPAWN_DEFAULT, {}, &child_output, &child_error, &exit_status);
-
 
   if(exit_status != 0){
     std::cout << "Error calling '"<< args[0] <<"'. " << child_error << std::endl;
     child_output = "{\"processes\": {}, \"profiles\": {}";
   } else {
-    Status::set_apply_label_text(" Changed '" + profile + "' from " + status + " to " + opposite_status.erase(0,3));
+    Status::set_apply_label_text(" Changed '" + profile + "' from " + status + " to " + new_status.erase(0,3));
   }
 
   return true;
@@ -71,7 +77,7 @@ void Profiles::change_status(){
   const auto path = col_record->get_row_data(row, 0);
   const auto status = col_record->get_row_data(row, 1);
   
-  if(!execute_change(path, status)) {
+  if(!execute_change(path, status)) { // this is useless at the moment (always true)
     std::cout << "Error changing the status" << std::endl;
   }
 

--- a/src/tabs/profiles.h
+++ b/src/tabs/profiles.h
@@ -24,9 +24,9 @@ class Profiles : public Status
     void change_status();
   
   protected:
-    // Signal handlers    
     void on_search_changed();
     void on_apply_button_pressed();
+    bool execute_change(const std::string& profile, const std::string& status);
 
   private:
     const std::vector<std::string> col_names{"Profile", "Status"};

--- a/src/tabs/status.cc
+++ b/src/tabs/status.cc
@@ -156,6 +156,10 @@ std::shared_ptr<Gtk::Spinner> Status::get_spinner(){
   return s_spinner;
 }
 
+Glib::ustring Status::get_selection_text() const {
+  return s_status_selection->get_active_text();
+}
+
 /* This is broken, should pull TreeSelection from s_view instead
 std::shared_ptr<Gtk::TreeSelection> Status::get_row(){
   return s_row;
@@ -182,7 +186,7 @@ Status::Status()
   s_apply_button{Status::get_widget<Gtk::Button>("s_apply_button", builder)},
   s_spinner{Status::get_widget<Gtk::Spinner>("s_spinner", builder)},
   s_apply_info_text{Status::get_widget<Gtk::Label>("s_apply_info_text", builder)},
-  s_status_selection{Status::get_widget<Gtk::ComboBox>("s_status_selection", builder)}
+  s_status_selection{Status::get_widget<Gtk::ComboBoxText>("s_status_selection", builder)}
 {
   s_win->set_shadow_type(Gtk::ShadowType::SHADOW_NONE);
   s_win->set_policy(Gtk::PolicyType::POLICY_AUTOMATIC, Gtk::PolicyType::POLICY_AUTOMATIC);

--- a/src/tabs/status.cc
+++ b/src/tabs/status.cc
@@ -132,6 +132,10 @@ void Status::set_status_label_text(const std::string& str){
   s_found_label->set_text(str);
 }
 
+void Status::set_apply_label_text(const std::string& str){
+  s_apply_info_text->set_text(str);
+}
+
 void Status::set_refresh_signal_handler(const Glib::SignalProxyProperty::SlotType& func){
   s_search->signal_search_changed().connect(func, true);
   s_use_regex->signal_clicked().connect(func, true);
@@ -148,6 +152,10 @@ std::shared_ptr<Gtk::TreeView> Status::get_view(){
   return s_view;
 }
 
+std::shared_ptr<Gtk::Spinner> Status::get_spinner(){
+  return s_spinner;
+}
+
 /* This is broken, should pull TreeSelection from s_view instead
 std::shared_ptr<Gtk::TreeSelection> Status::get_row(){
   return s_row;
@@ -162,7 +170,7 @@ void Status::remove_status_selection(){
 Status::Status()
 : builder{Gtk::Builder::create_from_resource("/resources/status.glade")},
   s_view{Status::get_widget<Gtk::TreeView>("s_view", builder)},
-  //s_row{Status::get_widget<Gtk::TreeSelection>("s_row", builder)},
+  //s_row{Status::get_widget<Gtk::TreeSelection>("s_row", builder)}, --- GTK does NOT like it when you do this
   s_win{Status::get_widget<Gtk::ScrolledWindow>("s_win", builder)},
   s_box{Status::get_widget<Gtk::Box>("s_box", builder)},
   s_search{Status::get_widget<Gtk::SearchEntry>("s_search", builder)},

--- a/src/tabs/status.cc
+++ b/src/tabs/status.cc
@@ -148,6 +148,12 @@ std::shared_ptr<Gtk::TreeView> Status::get_view(){
   return s_view;
 }
 
+/* This is broken, should pull TreeSelection from s_view instead
+std::shared_ptr<Gtk::TreeSelection> Status::get_row(){
+  return s_row;
+}
+*/
+
 void Status::remove_status_selection(){
   s_box->remove(*s_selection_box);
   s_selection_box->hide();
@@ -156,6 +162,7 @@ void Status::remove_status_selection(){
 Status::Status()
 : builder{Gtk::Builder::create_from_resource("/resources/status.glade")},
   s_view{Status::get_widget<Gtk::TreeView>("s_view", builder)},
+  //s_row{Status::get_widget<Gtk::TreeSelection>("s_row", builder)},
   s_win{Status::get_widget<Gtk::ScrolledWindow>("s_win", builder)},
   s_box{Status::get_widget<Gtk::Box>("s_box", builder)},
   s_search{Status::get_widget<Gtk::SearchEntry>("s_search", builder)},

--- a/src/tabs/status.h
+++ b/src/tabs/status.h
@@ -7,7 +7,7 @@
 #include <gtkmm/box.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/checkbutton.h>
-#include <gtkmm/combobox.h>
+#include <gtkmm/comboboxtext.h>
 #include <gtkmm/enums.h>
 #include <gtkmm/label.h>
 #include <gtkmm/liststore.h>
@@ -118,6 +118,13 @@ class Status : public Gtk::ScrolledWindow
     std::shared_ptr<Gtk::Spinner> get_spinner();
 
     /**
+     * @brief Return the active selection/choice in the dropdown ComboBoxText
+     * 
+     * @returns The string of the dropdown item which is selected.
+     */
+    Glib::ustring get_selection_text() const;
+
+    /**
      * @brief Make widgets related to changing profile status invisible to the user.
      * 
      * @details
@@ -145,11 +152,11 @@ class Status : public Gtk::ScrolledWindow
     std::unique_ptr<Gtk::Label>       s_found_label;
 
     // Widgets related to changing profile status (above search)
-    std::unique_ptr<Gtk::Box>         s_selection_box;
-    std::unique_ptr<Gtk::Button>      s_apply_button;
-    std::shared_ptr<Gtk::Spinner>     s_spinner;
-    std::unique_ptr<Gtk::Label>       s_apply_info_text;
-    std::unique_ptr<Gtk::ComboBox>    s_status_selection;
+    std::unique_ptr<Gtk::Box>             s_selection_box;
+    std::unique_ptr<Gtk::Button>          s_apply_button;
+    std::shared_ptr<Gtk::Spinner>         s_spinner;
+    std::unique_ptr<Gtk::Label>           s_apply_info_text;
+    std::unique_ptr<Gtk::ComboBoxText>    s_status_selection;
 
     template <typename T_Widget>
     static std::unique_ptr<T_Widget> get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder>& builder);    

--- a/src/tabs/status.h
+++ b/src/tabs/status.h
@@ -105,6 +105,16 @@ class Status : public Gtk::ScrolledWindow
      */
     std::shared_ptr<Gtk::TreeView> get_view();
 
+    /* BROKEN
+    /**
+     * @brief Return the TreeSelection associated with this class.
+     * 
+     * @returns The TreeSelection data member used by this class.
+     *
+    std::shared_ptr<Gtk::TreeSelection> get_row();
+    */
+
+
     /**
      * @brief Make widgets related to changing profile status invisible to the user.
      * 
@@ -121,7 +131,7 @@ class Status : public Gtk::ScrolledWindow
 
     // Container Widgets
     std::shared_ptr<Gtk::TreeView> s_view;
-    std::shared_ptr<Gtk::TreeSelection> s_row;
+    //std::shared_ptr<Gtk::TreeSelection> s_row;
     std::unique_ptr<Gtk::ScrolledWindow> s_win;
     std::unique_ptr<Gtk::Box> s_box;
 

--- a/src/tabs/status.h
+++ b/src/tabs/status.h
@@ -77,6 +77,11 @@ class Status : public Gtk::ScrolledWindow
     void set_status_label_text(const std::string& str);
 
     /**
+     * @brief Change the text in the label next to the Apply button/spinner.
+     */
+    void set_apply_label_text(const std::string& str);
+
+    /**
      * @brief Set the method to be called every time the search area updated.
      * 
      * @details
@@ -106,6 +111,13 @@ class Status : public Gtk::ScrolledWindow
     std::shared_ptr<Gtk::TreeView> get_view();
 
     /**
+     * @brief Return the Spinner associated with this class.
+     * 
+     * @returns The Spinner data member used by this class.
+     */
+    std::shared_ptr<Gtk::Spinner> get_spinner();
+
+    /**
      * @brief Make widgets related to changing profile status invisible to the user.
      * 
      * @details
@@ -121,7 +133,7 @@ class Status : public Gtk::ScrolledWindow
 
     // Container Widgets
     std::shared_ptr<Gtk::TreeView> s_view;
-    //std::shared_ptr<Gtk::TreeSelection> s_row;
+    //std::shared_ptr<Gtk::TreeSelection> s_row; --- GTK does NOT like it when you do this
     std::unique_ptr<Gtk::ScrolledWindow> s_win;
     std::unique_ptr<Gtk::Box> s_box;
 
@@ -135,7 +147,7 @@ class Status : public Gtk::ScrolledWindow
     // Widgets related to changing profile status (above search)
     std::unique_ptr<Gtk::Box>         s_selection_box;
     std::unique_ptr<Gtk::Button>      s_apply_button;
-    std::unique_ptr<Gtk::Spinner>     s_spinner;
+    std::shared_ptr<Gtk::Spinner>     s_spinner;
     std::unique_ptr<Gtk::Label>       s_apply_info_text;
     std::unique_ptr<Gtk::ComboBox>    s_status_selection;
 

--- a/src/tabs/status.h
+++ b/src/tabs/status.h
@@ -105,16 +105,6 @@ class Status : public Gtk::ScrolledWindow
      */
     std::shared_ptr<Gtk::TreeView> get_view();
 
-    /* BROKEN
-    /**
-     * @brief Return the TreeSelection associated with this class.
-     * 
-     * @returns The TreeSelection data member used by this class.
-     *
-    std::shared_ptr<Gtk::TreeSelection> get_row();
-    */
-
-
     /**
      * @brief Make widgets related to changing profile status invisible to the user.
      * 

--- a/src/tabs/status_column_record.cc
+++ b/src/tabs/status_column_record.cc
@@ -46,6 +46,14 @@ void StatusColumnRecord::set_row_data(const Gtk::TreeRow& row, const uint& index
     row[this->column[index]] = data;
 }
 
+std::string StatusColumnRecord::get_row_data(const Gtk::TreeRow& row, const uint& index) {
+    if(index >= column.size()){
+        throw std::out_of_range("Attempting to access invalid column.");
+    }
+
+    return row[this->column[index]];
+}
+
 
 void StatusColumnRecord::clear(){
     store->clear();

--- a/src/tabs/status_column_record.h
+++ b/src/tabs/status_column_record.h
@@ -67,6 +67,9 @@ class StatusColumnRecord : public Gtk::TreeModel::ColumnRecord
          */
         void set_row_data(const Gtk::TreeRow& row, const uint& index, const std::string& data);
 
+        // I'll do the comment later
+        std::string get_row_data(const Gtk::TreeRow& row, const uint& index);
+
         /**
          * @brief Deletes all rows in the StatusColumnRecord.
          */

--- a/usr.bin.firefox
+++ b/usr.bin.firefox
@@ -1,0 +1,307 @@
+# vim:syntax=apparmor
+# Author: Jamie Strandboge <jamie@canonical.com>
+
+# Declare an apparmor variable to help with overrides
+@{MOZ_LIBDIR}=/usr/lib/firefox
+
+#include <tunables/global>
+
+# We want to confine the binaries that match:
+#  /usr/lib/firefox/firefox
+#  /usr/lib/firefox/firefox
+# but not:
+#  /usr/lib/firefox/firefox.sh
+profile firefox /usr/lib/firefox/firefox{,*[^s][^h]} {
+  #include <abstractions/audio>
+  #include <abstractions/cups-client>
+  #include <abstractions/dbus-strict>
+  #include <abstractions/dbus-session-strict>
+  #include <abstractions/dconf>
+  #include <abstractions/gnome>
+  #include <abstractions/ibus>
+  #include <abstractions/nameservice>
+  #include <abstractions/openssl>
+  #include <abstractions/p11-kit>
+  #include <abstractions/ubuntu-unity7-base>
+  #include <abstractions/ubuntu-unity7-launcher>
+
+  #include <abstractions/dbus-accessibility-strict>
+  dbus (send)
+       bus=session
+       peer=(name=org.a11y.Bus),
+  dbus (receive)
+       bus=session
+       interface=org.a11y.atspi**,
+  dbus (receive, send)
+       bus=accessibility,
+
+  # for networking
+  network inet stream,
+  network inet6 stream,
+  @{PROC}/[0-9]*/net/arp r,
+  @{PROC}/[0-9]*/net/if_inet6 r,
+  @{PROC}/[0-9]*/net/ipv6_route r,
+  @{PROC}/[0-9]*/net/dev r,
+  @{PROC}/[0-9]*/net/wireless r,
+  dbus (send)
+       bus=system
+       path=/org/freedesktop/NetworkManager
+       member=state,
+  dbus (receive)
+       bus=system
+       path=/org/freedesktop/NetworkManager,
+
+  # should maybe be in abstractions
+  /etc/ r,
+  /etc/mime.types r,
+  /etc/mailcap r,
+  /etc/xdg/*buntu/applications/defaults.list    r, # for all derivatives
+  /etc/xfce4/defaults.list r,
+  /usr/share/xubuntu/applications/defaults.list r,
+  owner @{HOME}/.local/share/applications/defaults.list r,
+  owner @{HOME}/.local/share/applications/mimeapps.list r,
+  owner @{HOME}/.local/share/applications/mimeinfo.cache r,
+  /var/lib/snapd/desktop/applications/mimeinfo.cache r,
+  /var/lib/snapd/desktop/applications/*.desktop r,
+  owner /tmp/** m,
+  owner /var/tmp/** m,
+  owner /{,var/}run/shm/shmfd-* rw,
+  owner /{dev,run}/shm/org.{chromium,mozilla}.* rwk,
+  owner /{dev,run}/shm/wayland.mozilla.ipc.[0-9]* rw,
+  /tmp/.X[0-9]*-lock r,
+  /etc/udev/udev.conf r,
+  # Doesn't seem to be required, but noisy. Maybe allow 'r' for 'b*' if needed.
+  # Possibly move to an abstraction if anything else needs it.
+  deny /run/udev/data/** r,
+  # let the shell know we launched something
+  dbus (send)
+     bus=session
+     interface=org.gtk.gio.DesktopAppInfo
+     member=Launched,
+
+  /etc/timezone r,
+  /etc/wildmidi/wildmidi.cfg r,
+
+  # firefox specific
+  /etc/firefox*/ r,
+  /etc/firefox*/** r,
+  /etc/xul-ext/** r,
+  /etc/xulrunner-2.0*/ r,
+  /etc/xulrunner-2.0*/** r,
+  /etc/gre.d/ r,
+  /etc/gre.d/* r,
+
+  # noisy
+  deny @{MOZ_LIBDIR}/** w,
+  deny /usr/lib/firefox-addons/** w,
+  deny /usr/lib/xulrunner-addons/** w,
+  deny /usr/lib/xulrunner-*/components/*.tmp w,
+  deny /.suspended r,
+  deny /boot/initrd.img* r,
+  deny /boot/vmlinuz* r,
+  deny /var/cache/fontconfig/ w,
+  deny @{HOME}/.local/share/recently-used.xbel r,
+
+  # TODO: investigate
+  deny /usr/bin/gconftool-2 x,
+
+  # These are needed when a new user starts firefox and firefox.sh is used
+  @{MOZ_LIBDIR}/** ixr,
+  /usr/bin/basename ixr,
+  /usr/bin/dirname ixr,
+  /usr/bin/pwd ixr,
+  /sbin/killall5 ixr,
+  /bin/which ixr,
+  /usr/bin/tr ixr,
+  @{PROC}/ r,
+  @{PROC}/[0-9]*/cmdline r,
+  @{PROC}/[0-9]*/mountinfo r,
+  @{PROC}/[0-9]*/stat r,
+  owner @{PROC}/[0-9]*/task/[0-9]*/stat r,
+  @{PROC}/[0-9]*/status r,
+  @{PROC}/filesystems r,
+  @{PROC}/sys/vm/overcommit_memory r,
+  /sys/devices/pci[0-9]*/**/uevent r,
+  /sys/devices/platform/**/uevent r,
+  /sys/devices/pci*/**/{busnum,idVendor,idProduct} r,
+  /sys/devices/pci*/**/{,subsystem_}device r,
+  /sys/devices/pci*/**/{,subsystem_}vendor r,
+  /sys/devices/system/node/node[0-9]*/meminfo r,
+  owner @{HOME}/.cache/thumbnails/** rw,
+
+  /etc/mtab r,
+  /etc/fstab r,
+
+  # Needed for the crash reporter
+  owner @{PROC}/[0-9]*/environ r,
+  owner @{PROC}/[0-9]*/auxv r,
+  /etc/lsb-release r,
+  /usr/bin/expr ix,
+  /sys/devices/system/cpu/ r,
+  /sys/devices/system/cpu/** r,
+
+  # about:memory
+  owner @{PROC}/[0-9]*/statm r,
+  owner @{PROC}/[0-9]*/smaps r,
+
+  # Needed for container to work in xul builds
+  /usr/lib/xulrunner-*/plugin-container ixr,
+
+  # allow access to documentation and other files the user may want to look
+  # at in /usr and /opt
+  /usr/ r,
+  /usr/** r,
+  /opt/ r,
+  /opt/** r,
+
+  # so browsing directories works
+  / r,
+  /**/ r,
+
+  # Default profile allows downloads to ~/Downloads and uploads from ~/Public
+  owner @{HOME}/ r,
+  owner @{HOME}/Public/ r,
+  owner @{HOME}/Public/* r,
+  owner @{HOME}/Downloads/ r,
+  owner @{HOME}/Downloads/* rw,
+
+  # per-user firefox configuration
+  owner @{HOME}/.{firefox,mozilla}/ rw,
+  owner @{HOME}/.{firefox,mozilla}/** rw,
+  owner @{HOME}/.{firefox,mozilla}/**/*.{db,parentlock,sqlite}* k,
+  owner @{HOME}/.{firefox,mozilla}/plugins/** rm,
+  owner @{HOME}/.{firefox,mozilla}/**/plugins/** rm,
+  owner @{HOME}/.gnome2/firefox* rwk,
+  owner @{HOME}/.cache/mozilla/{,firefox/} rw,
+  owner @{HOME}/.cache/mozilla/firefox/** rw,
+  owner @{HOME}/.cache/mozilla/firefox/**/*.sqlite k,
+  owner @{HOME}/.config/gtk-3.0/bookmarks r,
+  owner @{HOME}/.config/dconf/user w,
+  owner /{,var/}run/user/*/dconf/user w,
+  dbus (send)
+       bus=session
+       path=/org/gnome/GConf/Server
+       member=GetDefaultDatabase
+       peer=(label=unconfined),
+  dbus (send)
+       bus=session
+       path=/org/gnome/GConf/Database/*
+       member={AddMatch,AddNotify,AllEntries,LookupExtended,RemoveNotify}
+       peer=(label=unconfined),
+  dbus (send)
+       bus=session
+       path=/org/gtk/vfs/mounttracker
+       interface=org.gtk.vfs.MountTracker
+       member=ListMountableInfo
+       peer=(label=unconfined),
+
+  # Allow remote control when running on Wayland
+  dbus (send)
+       bus=session
+       path=/org/freedesktop/DBus
+       interface=org.freedesktop.DBus
+       member=RequestName
+       peer=(name=org.freedesktop.DBus),
+  dbus (bind)
+       bus=session
+       name=org.mozilla.firefox.*,
+  dbus (send, receive)
+       bus=session
+       path=/org/mozilla/firefox/Remote
+       interface=org.mozilla.firefox
+       member=OpenURL
+       peer=(label=firefox),
+
+  # gnome-session
+  dbus (send)
+       bus=session
+       path=/org/gnome/SessionManager
+       interface=org.gnome.SessionManager
+       member={Inhibit,Uninhibit}
+       peer=(label=unconfined),
+
+  # unity screen API
+  dbus (send)
+       bus=system
+       interface="org.freedesktop.DBus.Introspectable"
+       path="/com/canonical/Unity/Screen"
+       member="Introspect"
+       peer=(label=unconfined),
+  dbus (send)
+       bus=system
+       interface="com.canonical.Unity.Screen"
+       path="/com/canonical/Unity/Screen"
+       member={keepDisplayOn,removeDisplayOnRequest}
+       peer=(label=unconfined),
+
+  # freedesktop.org ScreenSaver
+  dbus (send)
+       bus=session
+       path=/{,org/freedesktop/,org.gnome/}Screen{s,S}aver
+       interface=org.freedesktop.ScreenSaver
+       member={Inhibit,UnInhibit,SimulateUserActivity}
+       peer=(label=unconfined),
+
+  # gnome, kde and cinnamon screensaver
+  dbus (send)
+       bus=session
+       path=/{,ScreenSaver}
+       interface=org.{gnome.ScreenSaver,kde.screensaver,cinnamon.ScreenSaver}
+       member=SimulateUserActivity
+       peer=(label=unconfined),
+
+  # UPower
+  dbus (send)
+       bus=system
+       path=/org/freedesktop/UPower
+       interface=org.freedesktop.UPower
+       member=EnumerateDevices
+       peer=(label=unconfined),
+
+  #
+  # Extensions
+  # /usr/share/.../extensions/... is already covered by '/usr/** r', above.
+  # Allow 'x' for downloaded extensions, but inherit policy for safety
+  owner @{HOME}/.mozilla/**/extensions/** mixr,
+
+  deny @{MOZ_LIBDIR}/update.test w,
+  deny /usr/lib/mozilla/extensions/**/ w,
+  deny /usr/lib/xulrunner-addons/extensions/**/ w,
+  deny /usr/share/mozilla/extensions/**/ w,
+  deny /usr/share/mozilla/ w,
+
+  # Miscellaneous (to be abstracted)
+  # Ideally these would use a child profile. They are all ELF executables
+  # so running with 'Ux', while not ideal, is ok because we will at least
+  # benefit from glibc's secure execute.
+  /usr/bin/mkfifo Uxr,  # investigate
+  /bin/ps Uxr,
+  /bin/uname Uxr,
+
+  /usr/bin/lsb_release Cxr -> lsb_release,
+  profile lsb_release {
+    #include <abstractions/base>
+    #include <abstractions/python>
+    /usr/bin/lsb_release r,
+    /bin/dash ixr,
+    /usr/bin/dpkg-query ixr,
+    /usr/include/python2.[4567]/pyconfig.h r,
+    /etc/lsb-release r,
+    /etc/debian_version r,
+    /usr/share/distro-info/*.csv r,
+    /var/lib/dpkg/** r,
+
+    /usr/local/lib/python3.[0-9]/dist-packages/ r,
+    /usr/bin/ r,
+    /usr/bin/python3.[0-9] mr,
+
+    # file_inherit
+    deny /tmp/gtalkplugin.log w,
+  }
+
+  # Addons
+  #include <abstractions/ubuntu-browsers.d/firefox>
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include <local/usr.bin.firefox>
+}


### PR DESCRIPTION
Added 3 selection options to the dropdown menu (Enforce, Complain, Disable) which issue 'aa-enforce', 'aa-complain', and 'aa-disable' commands respectfully.

Added the ability to filter out paths with specified flags in the parser. More specifically, the transition-to-subprofile flags which were causing duplicate paths to be returned.

Note: we're still using the old way of simply just issuing console commands which seems to break for certain profiles including ones with 'snap', double slashes, and, more recently, Discord for some reason.