### PR TITLE
Update GitHub Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt upgrade
-        sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck xvfb clang-format-12
+        sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck clang-format-12
     
     - name: Configure CMake
       run: cmake .
@@ -44,15 +44,18 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt upgrade
+        sudo apt-get install xvfb
+
     - name: Download Binary Artifacts
       uses: actions/download-artifact@master
       with:
         name: dist
         path: dist
         if-no-files-found: error
-
-    - name: List
-      run: ls ./dist
 
     - name: Test
       # Run the unit tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build, Format, & Release
+name: Build & Test
 
 on: push
 
@@ -30,23 +30,9 @@ jobs:
       # Builds the binary any unit tests into the ./dist folder
       run: make
 
+  test:
+    needs: [build]
+
     - name: Test
       # Run the unit tests
       run: xvfb-run --auto-servernum ./dist/appanvil_test
-
-    #- name: setup git config
-    #  run: |
-    #    # setup the username and email for the bot. Using 'GitHub Actions Bot' with no email by default
-    #    git config user.name "GitHub Actions Bot"
-    #    git config user.email "<>"
-    #    
-    #- name: commit
-    #  run: |
-    #    num_files_changed=$(git diff --numstat | wc -l)
-    #    if [ $num_files_changed != 0 ]; then 
-    #      # Stage the changed files, commit and push
-    #      git add ./src/* ./test/src/* ./aa-caller/src/*;
-    #      git commit -m "Format code";
-    #      git push;
-    #    fi;
-        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt-get update
-        sudo apt upgrade
-        sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck clang-format-12
+        sudo apt-get update 2> /dev/null
+        sudo apt upgrade 2> /dev/null
+        sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck clang-format-12 2> /dev/null
     
     - name: Configure CMake
       run: cmake .
@@ -46,16 +46,15 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt-get update
-        sudo apt upgrade
-        sudo apt-get install xvfb
+        sudo apt-get update 2> /dev/null
+        sudo apt upgrade 2> /dev/null
+        sudo apt-get install xvfb 2> /dev/null
 
     - name: Download Binary Artifacts
       uses: actions/download-artifact@master
       with:
         name: dist
         path: dist
-        if-no-files-found: error
 
     - name: Test
       # Run the unit tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,39 +7,39 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+#   build:
+#     runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v2
+#     steps:
+#     - uses: actions/checkout@v2
 
-    - name: Install Dependencies
-      run: |
-        sudo apt-get update
-        sudo apt upgrade
-        sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck xvfb clang-format-12
+#     - name: Install Dependencies
+#       run: |
+#         sudo apt-get update
+#         sudo apt upgrade
+#         sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck xvfb clang-format-12
     
-    - name: Configure CMake
-      run: cmake .
+#     - name: Configure CMake
+#       run: cmake .
 
-    - name: Format Code
-      # Formats code using clang-format-12
-      run: make FORMAT
+#     - name: Format Code
+#       # Formats code using clang-format-12
+#       run: make FORMAT
 
-    - name: Build
-      # Builds the binary any unit tests into the ./dist folder
-      run: make
+#     - name: Build
+#       # Builds the binary any unit tests into the ./dist folder
+#       run: make
 
-    - name: Upload Binaries as Artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: dist
-        path: ./dist
-        if-no-files-found: error
+#     - name: Upload Binaries as Artifacts
+#       uses: actions/upload-artifact@v3
+#       with:
+#         name: dist
+#         path: ./dist
+#         if-no-files-found: error
 
   test:
     runs-on: ubuntu-latest
-    needs: [build]
+#     needs: [build]
 
     steps:
     - uses: actions/checkout@v2
@@ -51,6 +51,9 @@ jobs:
         name: dist
         # Destination path
         path: ./dist
+
+    - name: List
+      run: ls ./dist
 
     - name: Test
       # Run the unit tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,50 +7,49 @@ env:
   BUILD_TYPE: Release
 
 jobs:
-#   build:
-#     runs-on: ubuntu-latest
+  build:
+    runs-on: ubuntu-latest
 
-#     steps:
-#     - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
 
-#     - name: Install Dependencies
-#       run: |
-#         sudo apt-get update
-#         sudo apt upgrade
-#         sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck xvfb clang-format-12
+    - name: Install Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt upgrade
+        sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck xvfb clang-format-12
     
-#     - name: Configure CMake
-#       run: cmake .
+    - name: Configure CMake
+      run: cmake .
 
-#     - name: Format Code
-#       # Formats code using clang-format-12
-#       run: make FORMAT
+    - name: Format Code
+      # Formats code using clang-format-12
+      run: make FORMAT
 
-#     - name: Build
-#       # Builds the binary any unit tests into the ./dist folder
-#       run: make
+    - name: Build
+      # Builds the binary any unit tests into the ./dist folder
+      run: make
 
-#     - name: Upload Binaries as Artifacts
-#       uses: actions/upload-artifact@v3
-#       with:
-#         name: dist
-#         path: ./dist
-#         if-no-files-found: error
+    - name: Upload Binaries as Artifacts
+      uses: actions/upload-artifact@master
+      with:
+        name: dist
+        path: dist
+        if-no-files-found: error
 
   test:
     runs-on: ubuntu-latest
-#     needs: [build]
+    needs: [build]
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Download Binary Artifacts
-      uses: actions/download-artifact@v3.0.0
+      uses: actions/download-artifact@master
       with:
-        # Artifact name
         name: dist
-        # Destination path
-        path: ./dist
+        path: dist
+        if-no-files-found: error
 
     - name: List
       run: ls ./dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,12 @@ jobs:
       run: make
 
   test:
+    runs-on: ubuntu-latest
     needs: [build]
 
-    - name: Test
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
       # Run the unit tests
       run: xvfb-run --auto-servernum ./dist/appanvil_test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,4 +58,4 @@ jobs:
 
     - name: Test
       # Run the unit tests
-      run: xvfb-run --auto-servernum ./dist/appanvil_test
+      run: sudo xvfb-run --auto-servernum ./dist/appanvil_test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,9 @@ jobs:
         name: dist
         path: dist
 
+    - name: Download Binary Artifacts
+      run: chmod +x ./dist/appanvil_test
+
     - name: Test
       # Run the unit tests
-      run: sudo xvfb-run --auto-servernum ./dist/appanvil_test
+      run: xvfb-run --auto-servernum ./dist/appanvil_test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,13 @@ jobs:
       # Builds the binary any unit tests into the ./dist folder
       run: make
 
+    - name: Upload Binaries as Artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist
+        path: ./dist
+        if-no-files-found: error
+
   test:
     runs-on: ubuntu-latest
     needs: [build]
@@ -37,6 +44,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install Dependencies
+    - name: Download Binary Artifacts
+      uses: actions/download-artifact@v3.0.0
+      with:
+        # Artifact name
+        name: dist
+        # Destination path
+        path: ./dist
+
+    - name: Test
       # Run the unit tests
       run: xvfb-run --auto-servernum ./dist/appanvil_test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt-get update 2> /dev/null
-        sudo apt upgrade 2> /dev/null
-        sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck clang-format-12 2> /dev/null
+        sudo apt-get update 1> /dev/null
+        sudo apt upgrade 1> /dev/null
+        sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck clang-format-12 1> /dev/null
     
     - name: Configure CMake
       run: cmake .
@@ -46,9 +46,9 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        sudo apt-get update 2> /dev/null
-        sudo apt upgrade 2> /dev/null
-        sudo apt-get install xvfb 2> /dev/null
+        sudo apt-get update 1> /dev/null
+        sudo apt upgrade 1> /dev/null
+        sudo apt-get install xvfb libgtkmm-3.0-dev libjsoncpp-dev 1> /dev/null
 
     - name: Download Binary Artifacts
       uses: actions/download-artifact@master
@@ -56,7 +56,7 @@ jobs:
         name: dist
         path: dist
 
-    - name: Download Binary Artifacts
+    - name: Make Tests Executable
       run: chmod +x ./dist/appanvil_test
 
     - name: Test


### PR DESCRIPTION
I split the `build.yml` workflow into two _Jobs_. The first job builds AppAnvil, and saves the result as an artifact. The second job runs the unit tests, and checks that they pass.

I also removed the code auto-formatting for now, and may re-add that functionality when #21 is fixed.

This layout looks nicer when reviewing the workflow run results. It would be also good to create a separate job (or workflow file) to push the built code to the **Releases** section. Furthermore, we may want to build and test the project on multiple platforms.

I made multiple commits to GitHub to develop and test the functionality of my changes. When I merge, I'll probably make a squash commit, to not pollute the history.