### PR TITLE
Support DEB packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ compile_commands.json
 CTestTestfile.cmake
 _deps
 
+CPackConfig.cmake
+CPackSourceConfig.cmake
+_CPack_Packages/
+*.deb
+
 .cache/
 .vscode/
 build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,12 @@ install(
   DESTINATION bin
 )
 
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libgtkmm-3.0-dev,libjsoncpp-dev")
+set(CPACK_PACKAGE_CONTACT "Jack Ullery")
+set(CPACK_INSTALL_SCRIPT "cmake_install.cmake")
+include(CPack)
+
 #### Create install target to modify pkexec ####
 install(
   FILES ${PKEXEC_POLICY}


### PR DESCRIPTION
This is a small commit that changes `CMakeLists.txt` to enable packaging AppAnvil into a `.deb` file. I meant to push this change directly to main, but accidentally put it onto this branch.