### PR TITLE
Fix bug in ProfileAdapter + ProcessAdapter

### DIFF
--- a/src/tabs/model/process_adapter.cc
+++ b/src/tabs/model/process_adapter.cc
@@ -65,6 +65,7 @@ void ProcessAdapter<Database, ColumnRecord>::put_data(const std::string &process
         entry.row->set_value(3, status); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
         // Add the entry to the map
+        pid_map.erase(pid);
         pid_map.insert({pid, entry});
     }
     else {

--- a/src/tabs/model/profile_adapter.cc
+++ b/src/tabs/model/profile_adapter.cc
@@ -20,12 +20,14 @@ void ProfileAdapter<Database>::put_data(const std::string &profile_name, const s
         row->set_value(1, status);
 
         ProfileTableEntry entry(profile_name, status, row);
-        db->profile_data.emplace(profile_name, entry);
+        db->profile_data.insert({profile_name, entry});
     }
     else {
         // A pre-existing entry was found, so we should modify it
         ProfileTableEntry entry = iter->second;
         entry.status=status;
+        db->profile_data.erase(profile_name);
+        db->profile_data.insert({profile_name, entry});
     }
 }
 


### PR DESCRIPTION
This fixes a minor bug that would prevent _ProcessTableEntries_ and _ProfileTableEntries_ from being modified, after they were added to the table. After this PR is merged, all the unit-tests should finally pass.