### PR TITLE
Fix issue #22

### DIFF
--- a/src/tabs/controller/logs_controller.h
+++ b/src/tabs/controller/logs_controller.h
@@ -19,10 +19,12 @@ public:
   explicit LogsController(std::shared_ptr<Adapter> adapter, std::shared_ptr<LogsTab> logs);
 
   virtual void add_data_to_record(const std::string &data);
-  unsigned int num_visible_rows(); 
+
+  unsigned int num_visible_rows();
   void refresh();
 
 protected:
+  bool add_data_to_record_helper(std::shared_ptr<std::istringstream> json_data);
   void add_row_from_json(const Json::Value &entry);
 
 private:

--- a/src/threads/dispatcher_middleman.cc
+++ b/src/threads/dispatcher_middleman.cc
@@ -9,13 +9,18 @@
 #include "../tabs/view/processes.h"
 #include "../tabs/view/profiles.h"
 
+#include <glibmm/priorities.h>
 #include <mutex>
+#include <sigc++/functors/mem_fun.h>
 
 template<class Profiles, class Processes, class Logs, class Dispatcher, class Mutex>
 DispatcherMiddleman<Profiles, Processes, Logs, Dispatcher, Mutex>::DispatcherMiddleman(std::shared_ptr<Profiles> prof_arg,
                                                                                        std::shared_ptr<Processes> proc_arg,
                                                                                        std::shared_ptr<Logs> logs_arg)
-    : dispatch{new Dispatcher()}, prof{std::move(prof_arg)}, proc{std::move(proc_arg)}, logs{std::move(logs_arg)}
+  : dispatch{new Dispatcher()}, 
+    prof{std::move(prof_arg)}, 
+    proc{std::move(proc_arg)}, 
+    logs{std::move(logs_arg)}
 {
   auto function = sigc::mem_fun(*this, &DispatcherMiddleman<Profiles, Processes, Logs, Dispatcher, Mutex>::handle_signal);
   dispatch->connect(function);
@@ -69,7 +74,6 @@ void DispatcherMiddleman<Profiles, Processes, Logs, Dispatcher, Mutex>::update_p
 template<class Profiles, class Processes, class Logs, class Dispatcher, class Mutex>
 void DispatcherMiddleman<Profiles, Processes, Logs, Dispatcher, Mutex>::handle_signal()
 {
-
   CallData data = queue.pop();
 
   switch(data.type) {

--- a/test/src/tabs/controller/logs_controller_test.cc
+++ b/test/src/tabs/controller/logs_controller_test.cc
@@ -6,6 +6,7 @@
 #include <gmock/gmock-matchers.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <sstream>
 #include <string>
 
 using ::testing::_;
@@ -99,7 +100,8 @@ TEST_F(LogsControllerTest, TEST_ADD_DATA_TO_RECORD_VALID)
     .Times(1)
     .InSequence(add_row_calls);
 
-  logs_controller->add_data_to_record(data_arg);
+  auto data_stream = std::make_shared<std::istringstream>(data_arg);
+  logs_controller->add_data_to_record_helper(data_stream);
 }
 
 // Test for method add_data_to_record with an invalid argument passed
@@ -108,7 +110,8 @@ TEST_F(LogsControllerTest, TEST_ADD_DATA_TO_RECORD_INVALID)
   EXPECT_CALL(*adapter_mock, put_data(_, _, _, _, _, _)).Times(0);
   EXPECT_CALL(*adapter_mock, get_col_record()).Times(0);
 
-  EXPECT_THROW(logs_controller->add_data_to_record("{test}"), std::invalid_argument);
+  auto data_stream = std::make_shared<std::istringstream>("{test}");
+  EXPECT_THROW(logs_controller->add_data_to_record_helper(data_stream), std::invalid_argument);
 }
 
 // Test for method refresh()


### PR DESCRIPTION
### Description of issue
Previously, we had an issue where the _Logs_ tab would freeze when loading it for the first time. This would happen, because it takes a long time to read and parse a large number of logs.  

#### How the issue was solved
I changes how _LogsController_ parses logs. Previously, it parsed all the logs in one long for-loop. Now, it parses the logs in batches of 128 logs.  

When the `add_data_to_record(..))` method is called, it creates an idle function to parse logs when nothing else is happening. This means that, whenever the application is in use (for example if the user is clicking buttons), the idle function waits to be called. Eventually, when the function is finally called: it only parses 128 logs, and waits until the main loop is ready to call it again. 

#### What this means
Now the _Logs_ tab can be populated without freezing the application.

#### Any lingering issues
I did some research into using cursors, to control which logs journalctl reads. Cursors can be read directly from a log's json value. I think this approach could be helpful when refreshing the tab to look for more logs. It would be better to only look for logs after the most recent cursor, in addition to the changes made in this PR.  