### PR TITLE
Auto-Format code on Pull Request

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,16 +1,15 @@
 name: Auto-Format
 
-on: 
-  push:
-    branches:
-      - 'main'
+on:
+  pull_request_target:
+    types: [assigned, opened, synchronize, reopened]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release
 
 jobs:
-  build:
+  format:
     runs-on: ubuntu-22.04
 
     steps:
@@ -20,14 +19,11 @@ jobs:
       run: |
         sudo apt-get update 1> /dev/null
         sudo apt upgrade 1> /dev/null
-        sudo apt-get install libgtkmm-3.0-dev libjsoncpp-dev libgtest-dev libgmock-dev clang-tidy cppcheck clang-format 1> /dev/null
-
-    - name: Configure CMake
-      run: cmake .
+        sudo apt-get install clang-format 1> /dev/null
 
     - name: Format Code
       # Formats code using clang-format (version 14 or higher required)
-      run: make FORMAT
+      run: clang-format -style=file -i ./src/*.cc ./src/*.h ./src/*.inl ./test/src/*.cc ./test/src/*.h ./test/src/*.inl ./aa-caller/src/*.cc ./aa-caller/src/*.h ./aa-caller/src/*.inl
 
     - name: Configure Git
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ file(GLOB_RECURSE FORMAT_SOURCES
   ${CMAKE_CURRENT_BINARY_DIR}/test/src/*.cc
   ${CMAKE_CURRENT_BINARY_DIR}/test/src/*.h
   ${CMAKE_CURRENT_BINARY_DIR}/test/src/*.inl
+  ${CMAKE_CURRENT_BINARY_DIR}/aa-caller/src/*.cc
+  ${CMAKE_CURRENT_BINARY_DIR}/aa-caller/src/*.h
+  ${CMAKE_CURRENT_BINARY_DIR}/aa-caller/src/*.inl
 )
 
 set(PROJECT_RESOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/resources)


### PR DESCRIPTION
This is a continuation of #33. This action (if it works correctly) should automatically format and push code when PRs are made. 

This could be useful, because it ensures code is properly formatted before code review. 

The action is triggered by [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) which can sometimes be [problematic](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). However, it is written in a way to avoid those issues.