### PR TITLE
Capture code coverage reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: push
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Debug
+  BUILD_TYPE: Release
 
 jobs:
   build:
@@ -26,9 +26,13 @@ jobs:
       # Formats code using clang-format (version 14 or higher required)
       run: make FORMAT
 
-    - name: Build
-      # Builds the binary any unit tests into the ./dist folder
+    - name: Build AppAnvil
+      # Builds the 'appanvil' binary into the ./dist folder
       run: make
+
+    - name: Build Tests
+      # Builds the unit tests into the ./dist folder
+      run: make test
 
     - name: Upload Binaries as Artifacts
       uses: actions/upload-artifact@master
@@ -57,8 +61,8 @@ jobs:
         path: dist
 
     - name: Make Tests Executable
-      run: chmod +x ./dist/appanvil_test
+      run: chmod +x ./dist/test
 
     - name: Test
       # Run the unit tests
-      run: xvfb-run --auto-servernum ./dist/appanvil_test
+      run: xvfb-run --auto-servernum ./dist/test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on: push
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ resources/resource.autogen.c
 
 dist/
 lib/
+report/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ include_directories(
 
 #### Set Compiler Options ####
 set(CMAKE_CXX_FLAGS " -Wall -Wextra")
-set(CMAKE_CXX_FLAGS_DEBUG " -fprofile-arcs -ftest-coverage -Wall -Wextra -c -g")
+set(CMAKE_CXX_FLAGS_DEBUG " -fprofile-arcs -ftest-coverage -Wall -Wextra -g")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/dist)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -158,23 +158,18 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # set(CMAKE_LINK_WHAT_YOU_USE TRUE)
 
-#### Create a library used by the binary and unit tests ####
-set(LIBRARY_OUTPUT_NAME ${PROJECT_NAME}_dev)
-add_library(${LIBRARY_OUTPUT_NAME} STATIC ${RESOURCE_BUNDLE_OUTPUT} ${SOURCES})
+#### Create the main executable ####
+add_executable(${PROJECT_NAME} ${RESOURCE_BUNDLE_OUTPUT} ${SOURCES} ${PROJECT_SOURCE_DIR}/main.cc)
 
-target_include_directories(${LIBRARY_OUTPUT_NAME} SYSTEM PUBLIC ${GTKMM_INCLUDE_DIRS})
-target_include_directories(${LIBRARY_OUTPUT_NAME} SYSTEM PUBLIC ${jsoncpp_DIRS})
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${GTKMM_INCLUDE_DIRS})
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${jsoncpp_DIRS})
 
-target_link_libraries(${LIBRARY_OUTPUT_NAME} PUBLIC ${GTKMM_LIBRARIES})
-target_link_libraries(${LIBRARY_OUTPUT_NAME} PUBLIC jsoncpp)
-target_link_libraries(${LIBRARY_OUTPUT_NAME} PUBLIC pthread)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${GTKMM_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} PUBLIC jsoncpp)
+target_link_libraries(${PROJECT_NAME} PUBLIC pthread)
 
 add_subdirectory(aa-caller)
 add_subdirectory(test)
-
-#### Create the binary to the library ####
-add_executable(${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/main.cc)
-target_link_libraries(${PROJECT_NAME} PUBLIC ${LIBRARY_OUTPUT_NAME})
 
 #### Create install target to install binaries  ####
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ set(PROJECT_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/src)
 ### Sources that need to be built ###
 set(
   SOURCES
-  ${PROJECT_SOURCE_DIR}/main.cc
   ${PROJECT_SOURCE_DIR}/main_window.cc
   ${PROJECT_SOURCE_DIR}/console_thread.cc
   ${PROJECT_SOURCE_DIR}/threads/blocking_queue.cc
@@ -51,7 +50,6 @@ set(RESOURCE_BUNDLE_OUTPUT ${PROJECT_RESOURCE_DIR}/resource.autogen.c)
 
 set(PKEXEC_POLICY ${PROJECT_RESOURCE_DIR}/com.github.jack-ullery.AppAnvil.pkexec.policy)
 
-# set(REPORT_FILES_DIR ${CMAKE_BINARY_DIR}/test/CMakeFiles/${TEST_NAME}.dir)
 #### Add Linters and Static Analysis ####
 
 # If cmake was compiled with DANALYZE=TRUE
@@ -151,7 +149,7 @@ include_directories(
 )
 
 #### Set Compiler Options ####
-set(CMAKE_CXX_FLAGS " -Wall -Wextra -g")
+set(CMAKE_CXX_FLAGS " -Wall -Wextra")
 set(CMAKE_CXX_FLAGS_DEBUG " -fprofile-arcs -ftest-coverage -Wall -Wextra -g")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/dist)
@@ -175,7 +173,7 @@ add_subdirectory(aa-caller)
 add_subdirectory(test)
 
 #### Create the binary to the library ####
-add_executable(${PROJECT_NAME} ./src/main.cc)
+add_executable(${PROJECT_NAME} ${PROJECT_SOURCE_DIR}/main.cc)
 target_link_libraries(${PROJECT_NAME} PUBLIC ${LIBRARY_OUTPUT_NAME})
 
 #### Create install target to install binaries  ####

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ include_directories(
 
 #### Set Compiler Options ####
 set(CMAKE_CXX_FLAGS " -Wall -Wextra")
-set(CMAKE_CXX_FLAGS_DEBUG " -fprofile-arcs -ftest-coverage -Wall -Wextra -g")
+set(CMAKE_CXX_FLAGS_DEBUG " -fprofile-arcs -ftest-coverage -Wall -Wextra -c -g")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/dist)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -159,7 +159,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # set(CMAKE_LINK_WHAT_YOU_USE TRUE)
 
 #### Create a library used by the binary and unit tests ####
-set(LIBRARY_OUTPUT_NAME ${PROJECT_NAME}_main)
+set(LIBRARY_OUTPUT_NAME ${PROJECT_NAME}_dev)
 add_library(${LIBRARY_OUTPUT_NAME} STATIC ${RESOURCE_BUNDLE_OUTPUT} ${SOURCES})
 
 target_include_directories(${LIBRARY_OUTPUT_NAME} SYSTEM PUBLIC ${GTKMM_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project (appanvil)
 
 #### Set Source Code #####
 set(PROJECT_SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/src)
+
 ### Sources that need to be built ###
 set(
   SOURCES
@@ -50,6 +51,7 @@ set(RESOURCE_BUNDLE_OUTPUT ${PROJECT_RESOURCE_DIR}/resource.autogen.c)
 
 set(PKEXEC_POLICY ${PROJECT_RESOURCE_DIR}/com.github.jack-ullery.AppAnvil.pkexec.policy)
 
+# set(REPORT_FILES_DIR ${CMAKE_BINARY_DIR}/test/CMakeFiles/${TEST_NAME}.dir)
 #### Add Linters and Static Analysis ####
 
 # If cmake was compiled with DANALYZE=TRUE
@@ -150,6 +152,8 @@ include_directories(
 
 #### Set Compiler Options ####
 set(CMAKE_CXX_FLAGS " -Wall -Wextra -g")
+set(CMAKE_CXX_FLAGS_DEBUG " -fprofile-arcs -ftest-coverage -Wall -Wextra -g")
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/dist)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,6 @@ include_directories(
 
 #### Set Compiler Options ####
 set(CMAKE_CXX_FLAGS " -Wall -Wextra")
-set(CMAKE_CXX_FLAGS_DEBUG " -fprofile-arcs -ftest-coverage -Wall -Wextra -g")
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/dist)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ To generate a makefile, build, install, and run extra static analysis on the sou
 $ cmake -DANALYZE=TRUE .
 $ sudo make install
 ```
+To build the unit tests:
+```
+$ make test
+```
 To format code, without building it:
 ```
 $ make FORMAT
@@ -69,7 +73,7 @@ To run the resulting binary:
 ```
 $ appanvil
 ```
-To run unit tests (need googletest & googlemock installed):
+To run the unit tests (need to be built first):
 ```
-$ ./dist/appanvil_test
+$ ./dist/test
 ```

--- a/README.md
+++ b/README.md
@@ -42,38 +42,52 @@ Unit Tests
 * googlemock (libgmock-dev)
 
 # Compilation Instructions
+### Prebuild
+Before you build the executable, you must first generate the makefile by running:
+```
+cmake .
+```
+Alternatively, if you want to run optional linters and static analysis checks:
+```
+cmake -DANALYZE=TRUE .
+```
 
-To generate a makefile, build, and install the project using that makefile:
+### Build
+After the makefile is generated, you can build and install the executables:
 ```
-$ cmake .
-$ sudo make install
+sudo make install
 ```
-To generate a makefile, build, install, and run extra static analysis on the source code:
-```
-$ cmake -DANALYZE=TRUE .
-$ sudo make install
-```
+This builds the necessary executables, installs them, and applies recommended changes to PolicyKit.
+
+### Test
 To build the unit tests:
 ```
-$ make test
+make test
 ```
+To generate a code coverage report:
+```
+make report
+```
+Afterwards, you can then view the report by opening `./report/index.html` inside a web browser.
+
+### Automatically Format Code
 To format code, without building it:
 ```
-$ make FORMAT
+make FORMAT
 ```
 # Uninstall Instructions
 
 To uninstall AppAnvil binaries and pkexec policy from the system:
 ```
-$ sudo make uninstall
+sudo make uninstall
 ```
 
 # Run
 To run the resulting binary:
 ```
-$ appanvil
+appanvil
 ```
 To run the unit tests (need to be built first):
 ```
-$ ./dist/test
+./dist/test
 ```

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(TEST_NAME ${PROJECT_NAME}_test)
+set(TEST_NAME test)
 cmake_minimum_required (VERSION 3.16.3)
 
 set(
@@ -32,7 +32,7 @@ pkg_check_modules(GMOCK gmock)
 if(${GTEST_FOUND} AND ${GMOCK_FOUND})
   message(STATUS "Adding unit tests to build")
 
-  add_executable(${TEST_NAME} ${TEST_SOURCES})
+  add_executable(${TEST_NAME} EXCLUDE_FROM_ALL ${TEST_SOURCES} ${SOURCES})
 
   # Do not use clang-tidy on test code
   set_target_properties(${TEST_NAME} PROPERTIES CXX_CLANG_TIDY "")
@@ -44,8 +44,6 @@ if(${GTEST_FOUND} AND ${GMOCK_FOUND})
   target_link_libraries(${TEST_NAME} PUBLIC pthread)
   target_link_libraries(${TEST_NAME} PUBLIC jsoncpp)
   target_link_libraries(${TEST_NAME} PUBLIC ${GTKMM_LIBRARIES})
-
-  target_link_libraries(${TEST_NAME} PUBLIC ${LIBRARY_OUTPUT_NAME})
 
   # Create target "report", which should run the unit-tests and generate a code coverage report  
   add_custom_target(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,21 +49,33 @@ if(${GTEST_FOUND} AND ${GMOCK_FOUND})
 
   # Create target "REPORT", which should run the unit-tests and generate a code coverage report  
   add_custom_target(
-    TEST_DATA
-    COMMAND ${CMAKE_BINARY_DIR}/dist/appanvil_test
+    LCOV_BASE
+    COMMAND lcov -c -i --no-external --exclude */test/* --exclude *.c -d ${CMAKE_BINARY_DIR} -o ${REPORT_FILES_DIR}/base_coverage.info
     DEPENDS appanvil_test
   )
 
   add_custom_target(
-    LCOV
-    COMMAND lcov -c --exclude '/usr/*' -d ${REPORT_FILES_DIR}/src --output-file ${REPORT_FILES_DIR}/test_coverage.info
+    TEST_DATA
+    COMMAND ${CMAKE_BINARY_DIR}/dist/appanvil_test
+    DEPENDS LCOV_BASE
+  )
+
+  add_custom_target(
+    LCOV_TEST
+    COMMAND lcov -c --exclude '/usr/*','*.c' --include '*/AppAnvil/src/*' -d ${REPORT_FILES_DIR} -o ${REPORT_FILES_DIR}/test_coverage.info
     DEPENDS TEST_DATA
+  )
+
+  add_custom_target(
+    LCOV
+    COMMAND lcov -a ${REPORT_FILES_DIR}/base_coverage.info -a ${REPORT_FILES_DIR}/test_coverage.info -o ${REPORT_FILES_DIR}/total_coverage.info
+    DEPENDS LCOV_TEST
   )
 
   add_custom_target(
     REPORT
     DEPENDS LCOV
-    COMMAND genhtml ${REPORT_FILES_DIR}/test_coverage.info --output-directory ${PROJECT_SOURCE_DIR}/../report
+    COMMAND genhtml ${REPORT_FILES_DIR}/total_coverage.info --output-directory ${PROJECT_SOURCE_DIR}/../report
   )
 
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -47,16 +47,16 @@ if(${GTEST_FOUND} AND ${GMOCK_FOUND})
 
   target_link_libraries(${TEST_NAME} PUBLIC ${LIBRARY_OUTPUT_NAME})
 
-  # Create target "REPORT", which should run the unit-tests and generate a code coverage report  
+  # Create target "report", which should run the unit-tests and generate a code coverage report  
   add_custom_target(
     LCOV_BASE
     COMMAND lcov -c -i --no-external --exclude */test/* --exclude *.c -d ${CMAKE_BINARY_DIR} -o ${REPORT_FILES_DIR}/base_coverage.info
-    DEPENDS appanvil_test
+    DEPENDS ${TEST_NAME}
   )
 
   add_custom_target(
     TEST_DATA
-    COMMAND ${CMAKE_BINARY_DIR}/dist/appanvil_test
+    COMMAND ${CMAKE_BINARY_DIR}/dist/${TEST_NAME}
     DEPENDS LCOV_BASE
   )
 
@@ -73,11 +73,10 @@ if(${GTEST_FOUND} AND ${GMOCK_FOUND})
   )
 
   add_custom_target(
-    REPORT
+    report
     DEPENDS LCOV
     COMMAND genhtml ${REPORT_FILES_DIR}/total_coverage.info --output-directory ${PROJECT_SOURCE_DIR}/../report
   )
-
 
 else()
   message(WARNING "Could not find googletest and googlemock packages. Please install them if you want to enable unit tests.")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,9 @@ set(
   ./src/threads/blocking_queue.cc
 )
 
+set(REPORT_FILES_DIR ${CMAKE_BINARY_DIR}/test/CMakeFiles/${TEST_NAME}.dir)
+message(${REPORT_FILES_DIR})
+
 #====================================
 
 find_package(PkgConfig)
@@ -28,7 +31,7 @@ pkg_check_modules(GMOCK gmock)
 
 if(${GTEST_FOUND} AND ${GMOCK_FOUND})
   message(STATUS "Adding unit tests to build")
-  # set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ../dist)
+
   add_executable(${TEST_NAME} ${TEST_SOURCES})
 
   # Do not use clang-tidy on test code
@@ -43,6 +46,27 @@ if(${GTEST_FOUND} AND ${GMOCK_FOUND})
   target_link_libraries(${TEST_NAME} PUBLIC ${GTKMM_LIBRARIES})
 
   target_link_libraries(${TEST_NAME} PUBLIC ${LIBRARY_OUTPUT_NAME})
+
+  # Create target "REPORT", which should run the unit-tests and generate a code coverage report  
+  add_custom_target(
+    TEST_DATA
+    COMMAND ${CMAKE_BINARY_DIR}/dist/appanvil_test
+    DEPENDS appanvil_test
+  )
+
+  add_custom_target(
+    LCOV
+    COMMAND lcov -c --exclude '/usr/*' -d ${REPORT_FILES_DIR}/src --output-file ${REPORT_FILES_DIR}/test_coverage.info
+    DEPENDS TEST_DATA
+  )
+
+  add_custom_target(
+    REPORT
+    DEPENDS LCOV
+    COMMAND genhtml ${REPORT_FILES_DIR}/test_coverage.info --output-directory ${PROJECT_SOURCE_DIR}/../report
+  )
+
+
 else()
   message(WARNING "Could not find googletest and googlemock packages. Please install them if you want to enable unit tests.")
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,6 +36,7 @@ if(${GTEST_FOUND} AND ${GMOCK_FOUND})
 
   # Do not use clang-tidy on test code
   set_target_properties(${TEST_NAME} PROPERTIES CXX_CLANG_TIDY "")
+  set_target_properties(${TEST_NAME} PROPERTIES CMAKE_CXX_FLAGS_DEBUG " -fprofile-arcs -ftest-coverage -Wall -Wextra -g")
 
   target_include_directories(${TEST_NAME} SYSTEM PUBLIC ${GTKMM_INCLUDE_DIRS})
 


### PR DESCRIPTION
### Description of changes

#### Capture code coverage
These changes modify the build, so that code coverage reports can now be captured easily. A code coverage report can be generated by running `make report`. Afterwards, you can view the HTML report by opening the `./report/index.html` file.

#### Modifications to unit test build
I also changed the build process for the unit tests. Previously, the unit test would be built automatically with the main binary. Now, you must explicitly build the unit tests using `make test`. In doing this, the name of the resulting test binary changed from `./dist/appanvil_test` to `./dist/test` 

#### Modifications to GitHub actions and README.md
Updates were made to both [github/workflows/build.yml](https://github.com/jack-ullery/AppAnvil/blob/d570f70efc07a56c482ab63e17184112b211d590/.github/workflows/build.yml) and [README.md](https://github.com/jack-ullery/AppAnvil/blob/code-coverage/README.md) reflect the above changes.