### PR TITLE
Fix error with auto-format code action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Format Code
       # Formats code using clang-format (version 14 or higher required)
-      run: clang-format -style=file -i ./src/*.cc ./src/*.h ./src/*.inl ./test/src/*.cc ./test/src/*.h ./test/src/*.inl ./aa-caller/src/*.cc ./aa-caller/src/*.h ./aa-caller/src/*.inl
+      run: find src test/src aa-caller/src -iname *.cc -o -iname *.h -o -iname *.inl | xargs clang-format -style=file -i
 
     - name: Configure Git
       run: |


### PR DESCRIPTION
This fixes an error introduced by PR #34, which called _clang-format_ in an incorrect way. The error would prevent the code from being formatted correctly. This fix should change that.