### PR TITLE
Common view functions

### DIFF
--- a/src/tabs/view/common.h
+++ b/src/tabs/view/common.h
@@ -13,7 +13,7 @@ public:
   // Gets a shared pointer to a widget defined by a Gtk::Builder
   template<typename T_Widget>
   static std::shared_ptr<T_Widget> get_widget_shared(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);
-  
+
   // Gets a unique pointer to a widget defined by a Gtk::Builder
   template<typename T_Widget>
   static std::unique_ptr<T_Widget> get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);

--- a/src/tabs/view/common.h
+++ b/src/tabs/view/common.h
@@ -1,0 +1,40 @@
+#ifndef TABS_VIEW_COMMON_FUNCTIONS_H
+#define TABS_VIEW_COMMON_FUNCTIONS_H
+
+#include <gtkmm/bin.h>
+#include <gtkmm/box.h>
+#include <gtkmm/builder.h>
+#include <gtkmm/label.h>
+#include <memory>
+
+class Common
+{
+public:
+  // Gets a shared pointer to a widget defined by a Gtk::Builder
+  template<typename T_Widget>
+  static std::shared_ptr<T_Widget> get_widget_shared(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);
+  
+  // Gets a unique pointer to a widget defined by a Gtk::Builder
+  template<typename T_Widget>
+  static std::unique_ptr<T_Widget> get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);
+};
+
+// Included definition for functions in header file to avoid annoying linker issues with templates
+
+template<typename T_Widget>
+std::unique_ptr<T_Widget> Common::get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder)
+{
+  T_Widget *raw_addr = nullptr;
+  builder->get_widget<T_Widget>(name, raw_addr);
+  return std::unique_ptr<T_Widget>(raw_addr);
+}
+
+template<typename T_Widget>
+std::shared_ptr<T_Widget> Common::get_widget_shared(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder)
+{
+  T_Widget *raw_addr = nullptr;
+  builder->get_widget<T_Widget>(name, raw_addr);
+  return std::shared_ptr<T_Widget>(raw_addr);
+}
+
+#endif // TABS_VIEW_COMMON_FUNCTIONS_H

--- a/src/tabs/view/help.cc
+++ b/src/tabs/view/help.cc
@@ -1,5 +1,5 @@
-#include "common.h"
 #include "help.h"
+#include "common.h"
 
 #include <string>
 #include <vector>

--- a/src/tabs/view/help.cc
+++ b/src/tabs/view/help.cc
@@ -1,23 +1,16 @@
+#include "common.h"
 #include "help.h"
 
 #include <string>
 #include <vector>
 
-template<typename T_Widget>
-std::unique_ptr<T_Widget> Help::get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder)
-{
-  T_Widget *raw_addr = nullptr;
-  builder->get_widget<T_Widget>(name, raw_addr);
-  return std::unique_ptr<T_Widget>(raw_addr);
-}
-
 Help::Help()
   : builder{ Gtk::Builder::create_from_resource("/resources/help.glade") },
-    h_box{ Help::get_widget<Gtk::Box>("h_box", builder) },
-    h_label{ Help::get_widget<Gtk::Label>("h_label", builder) },
-    h_searchbox{ Help::get_widget<Gtk::Box>("h_searchbox", builder) },
-    h_search{ Help::get_widget<Gtk::SearchEntry>("h_search", builder) },
-    h_return_button{ Help::get_widget<Gtk::Button>("h_return_button", builder) },
+    h_box{ Common::get_widget<Gtk::Box>("h_box", builder) },
+    h_label{ Common::get_widget<Gtk::Label>("h_label", builder) },
+    h_searchbox{ Common::get_widget<Gtk::Box>("h_searchbox", builder) },
+    h_search{ Common::get_widget<Gtk::SearchEntry>("h_search", builder) },
+    h_return_button{ Common::get_widget<Gtk::Button>("h_return_button", builder) },
     description{ h_label->get_label() }
 {
   auto search_func = sigc::mem_fun(*this, &Help::on_search_changed);

--- a/src/tabs/view/help.h
+++ b/src/tabs/view/help.h
@@ -49,9 +49,6 @@ private:
   // The text that is shown
   // const std::string description;
   const std::string description;
-
-  template<typename T_Widget>
-  static std::unique_ptr<T_Widget> get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);
 };
 
 #endif // TABS_VIEW_HELP_H

--- a/src/tabs/view/info_box.cc
+++ b/src/tabs/view/info_box.cc
@@ -1,12 +1,5 @@
+#include "common.h"
 #include "info_box.h"
-
-template<typename T_Widget>
-std::unique_ptr<T_Widget> InfoBox::get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder)
-{
-  T_Widget *raw_addr = nullptr;
-  builder->get_widget<T_Widget>(name, raw_addr);
-  return std::unique_ptr<T_Widget>(raw_addr);
-}
 
 void InfoBox::set_text(const std::string &header, const std::string &text)
 {
@@ -16,9 +9,9 @@ void InfoBox::set_text(const std::string &header, const std::string &text)
 
 InfoBox::InfoBox()
   : builder{ Gtk::Builder::create_from_resource("/resources/info_box.glade") },
-    i_box{ InfoBox::get_widget<Gtk::Box>("i_box", builder) },
-    i_header{ InfoBox::get_widget<Gtk::Label>("i_header", builder) },
-    i_text{ InfoBox::get_widget<Gtk::Label>("i_text", builder) }
+    i_box{ Common::get_widget<Gtk::Box>("i_box", builder) },
+    i_header{ Common::get_widget<Gtk::Label>("i_header", builder) },
+    i_text{ Common::get_widget<Gtk::Label>("i_text", builder) }
 {
   i_header->set_text("");
   i_text->set_text("");

--- a/src/tabs/view/info_box.cc
+++ b/src/tabs/view/info_box.cc
@@ -1,5 +1,5 @@
-#include "common.h"
 #include "info_box.h"
+#include "common.h"
 
 void InfoBox::set_text(const std::string &header, const std::string &text)
 {

--- a/src/tabs/view/info_box.h
+++ b/src/tabs/view/info_box.h
@@ -23,10 +23,6 @@ private:
   std::unique_ptr<Gtk::Box> i_box;
   std::unique_ptr<Gtk::Label> i_header;
   std::unique_ptr<Gtk::Label> i_text;
-
-  // Misc
-  template<typename T_Widget>
-  static std::unique_ptr<T_Widget> get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);
 };
 
 #endif // TABS_VIEW_INFO_BOX_H

--- a/src/tabs/view/logs.cc
+++ b/src/tabs/view/logs.cc
@@ -1,5 +1,5 @@
-#include "common.h"
 #include "logs.h"
+#include "common.h"
 #include "info_box.h"
 
 void Logs::set_information(std::list<std::pair<std::string, std::string>> data)

--- a/src/tabs/view/logs.cc
+++ b/src/tabs/view/logs.cc
@@ -1,14 +1,6 @@
+#include "common.h"
 #include "logs.h"
 #include "info_box.h"
-
-// TODO: Make get_widget common function somewhere
-template<typename T_Widget>
-std::unique_ptr<T_Widget> Logs::get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder)
-{
-  T_Widget *raw_addr = nullptr;
-  builder->get_widget<T_Widget>(name, raw_addr);
-  return std::unique_ptr<T_Widget>(raw_addr);
-}
 
 void Logs::set_information(std::list<std::pair<std::string, std::string>> data)
 {
@@ -37,7 +29,7 @@ void Logs::set_information(std::list<std::pair<std::string, std::string>> data)
 Logs::Logs()
   : Status("/resources/log.glade"),
     builder{ Status::get_builder() },
-    l_log_info{ Logs::get_widget<Gtk::Box>("l_log_info", builder) },
+    l_log_info{ Common::get_widget<Gtk::Box>("l_log_info", builder) },
     info_vec()
 {
   this->show_all();

--- a/src/tabs/view/logs.h
+++ b/src/tabs/view/logs.h
@@ -28,10 +28,6 @@ private:
 
   // Widgets
   std::vector<InfoBox> info_vec;
-
-  // Misc
-  template<typename T_Widget>
-  static std::unique_ptr<T_Widget> get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);
 };
 
 #endif // TABS_VIEW_LOGS_H

--- a/src/tabs/view/profile_loader.cc
+++ b/src/tabs/view/profile_loader.cc
@@ -1,23 +1,16 @@
+#include "common.h"
 #include "profile_loader.h"
 
 #include <iostream>
 #include <string>
 #include <vector>
 
-template<typename T_Widget>
-std::unique_ptr<T_Widget> ProfileLoader::get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder)
-{
-  T_Widget *raw_addr = nullptr;
-  builder->get_widget<T_Widget>(name, raw_addr);
-  return std::unique_ptr<T_Widget>(raw_addr);
-}
-
 ProfileLoader::ProfileLoader()
   : builder{ Gtk::Builder::create_from_resource("/resources/load_profile.glade") },
-    l_box{ ProfileLoader::get_widget<Gtk::Box>("l_box", builder) },
-    l_filechooser_button{ ProfileLoader::get_widget<Gtk::FileChooser>("l_filechooser_button", builder) },
-    l_confirm_label{ ProfileLoader::get_widget<Gtk::Label>("l_confirm_label", builder) },
-    l_confirm_button{ ProfileLoader::get_widget<Gtk::Button>("l_confirm_button", builder) }
+    l_box{ Common::get_widget<Gtk::Box>("l_box", builder) },
+    l_filechooser_button{ Common::get_widget<Gtk::FileChooser>("l_filechooser_button", builder) },
+    l_confirm_label{ Common::get_widget<Gtk::Label>("l_confirm_label", builder) },
+    l_confirm_button{ Common::get_widget<Gtk::Button>("l_confirm_button", builder) }
 {
   l_box->set_hexpand();
   l_box->set_vexpand();

--- a/src/tabs/view/profile_loader.cc
+++ b/src/tabs/view/profile_loader.cc
@@ -1,5 +1,5 @@
-#include "common.h"
 #include "profile_loader.h"
+#include "common.h"
 
 #include <iostream>
 #include <string>

--- a/src/tabs/view/profile_loader.h
+++ b/src/tabs/view/profile_loader.h
@@ -30,9 +30,6 @@ private:
   std::unique_ptr<Gtk::FileChooser> l_filechooser_button;
   std::unique_ptr<Gtk::Label> l_confirm_label;
   std::unique_ptr<Gtk::Button> l_confirm_button;
-
-  template<typename T_Widget>
-  static std::unique_ptr<T_Widget> get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);
 };
 
 #endif // TABS_PROFILES_H

--- a/src/tabs/view/profiles.cc
+++ b/src/tabs/view/profiles.cc
@@ -1,6 +1,6 @@
-#include "common.h"
 #include "profiles.h"
 #include "../model/status_column_record.h"
+#include "common.h"
 
 #include "jsoncpp/json/json.h"
 #include "profile_loader.h"

--- a/src/tabs/view/profiles.cc
+++ b/src/tabs/view/profiles.cc
@@ -102,17 +102,17 @@ void Profiles::handle_load_profile_toggle()
 Profiles::Profiles()
   : Status("/resources/profile.glade"),
     builder{ Status::get_builder() },
-    p_change_state_toggle{ Common::get_widget_shared<Gtk::ToggleButton>("p_change_state_toggle", builder) },
-    p_load_profile_toggle{ Common::get_widget_shared<Gtk::ToggleButton>("p_load_profile_toggle", builder) },
-    p_stack{ Common::get_widget_shared<Gtk::Stack>("p_stack", builder) },
-    p_state_selection_box{ Common::get_widget_shared<Gtk::Box>("p_state_selection_box", builder) },
-    p_status_selection{ Common::get_widget_shared<Gtk::ComboBoxText>("p_status_selection", builder) },
-    p_apply_button{ Common::get_widget_shared<Gtk::Button>("p_apply_button", builder) },
-    p_apply_info_text{ Common::get_widget_shared<Gtk::Label>("p_apply_info_text", builder) },
-    p_profile_info{ Common::get_widget_shared<Gtk::Box>("p_profile_info", builder) },
-    p_num_log_label{ Common::get_widget_shared<Gtk::Label>("p_num_log_label", builder) },
-    p_num_proc_label{ Common::get_widget_shared<Gtk::Label>("p_num_proc_label", builder) },
-    p_num_perm_label{ Common::get_widget_shared<Gtk::Label>("p_num_perm_label", builder) },
+    p_change_state_toggle{ Common::get_widget<Gtk::ToggleButton>("p_change_state_toggle", builder) },
+    p_load_profile_toggle{ Common::get_widget<Gtk::ToggleButton>("p_load_profile_toggle", builder) },
+    p_stack{ Common::get_widget<Gtk::Stack>("p_stack", builder) },
+    p_state_selection_box{ Common::get_widget<Gtk::Box>("p_state_selection_box", builder) },
+    p_status_selection{ Common::get_widget<Gtk::ComboBoxText>("p_status_selection", builder) },
+    p_apply_button{ Common::get_widget<Gtk::Button>("p_apply_button", builder) },
+    p_apply_info_text{ Common::get_widget<Gtk::Label>("p_apply_info_text", builder) },
+    p_profile_info{ Common::get_widget<Gtk::Box>("p_profile_info", builder) },
+    p_num_log_label{ Common::get_widget<Gtk::Label>("p_num_log_label", builder) },
+    p_num_proc_label{ Common::get_widget<Gtk::Label>("p_num_proc_label", builder) },
+    p_num_perm_label{ Common::get_widget<Gtk::Label>("p_num_perm_label", builder) },
     loader{ new ProfileLoader() }
 {
   // Add tabs to the stack pane

--- a/src/tabs/view/profiles.cc
+++ b/src/tabs/view/profiles.cc
@@ -1,3 +1,4 @@
+#include "common.h"
 #include "profiles.h"
 #include "../model/status_column_record.h"
 
@@ -13,14 +14,6 @@
 #include <string>
 #include <tuple>
 #include <vector>
-
-template<typename T_Widget>
-std::shared_ptr<T_Widget> Profiles::get_widget_shared(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder)
-{
-  T_Widget *raw_addr = nullptr;
-  builder->get_widget<T_Widget>(name, raw_addr);
-  return std::shared_ptr<T_Widget>(raw_addr);
-}
 
 void Profiles::change_status()
 {
@@ -109,17 +102,17 @@ void Profiles::handle_load_profile_toggle()
 Profiles::Profiles()
   : Status("/resources/profile.glade"),
     builder{ Status::get_builder() },
-    p_change_state_toggle{ get_widget_shared<Gtk::ToggleButton>("p_change_state_toggle", builder) },
-    p_load_profile_toggle{ get_widget_shared<Gtk::ToggleButton>("p_load_profile_toggle", builder) },
-    p_stack{ get_widget_shared<Gtk::Stack>("p_stack", builder) },
-    p_state_selection_box{ get_widget_shared<Gtk::Box>("p_state_selection_box", builder) },
-    p_status_selection{ get_widget_shared<Gtk::ComboBoxText>("p_status_selection", builder) },
-    p_apply_button{ get_widget_shared<Gtk::Button>("p_apply_button", builder) },
-    p_apply_info_text{ get_widget_shared<Gtk::Label>("p_apply_info_text", builder) },
-    p_profile_info{ get_widget_shared<Gtk::Box>("p_profile_info", builder) },
-    p_num_log_label{ get_widget_shared<Gtk::Label>("p_num_log_label", builder) },
-    p_num_proc_label{ get_widget_shared<Gtk::Label>("p_num_proc_label", builder) },
-    p_num_perm_label{ get_widget_shared<Gtk::Label>("p_num_perm_label", builder) },
+    p_change_state_toggle{ Common::get_widget_shared<Gtk::ToggleButton>("p_change_state_toggle", builder) },
+    p_load_profile_toggle{ Common::get_widget_shared<Gtk::ToggleButton>("p_load_profile_toggle", builder) },
+    p_stack{ Common::get_widget_shared<Gtk::Stack>("p_stack", builder) },
+    p_state_selection_box{ Common::get_widget_shared<Gtk::Box>("p_state_selection_box", builder) },
+    p_status_selection{ Common::get_widget_shared<Gtk::ComboBoxText>("p_status_selection", builder) },
+    p_apply_button{ Common::get_widget_shared<Gtk::Button>("p_apply_button", builder) },
+    p_apply_info_text{ Common::get_widget_shared<Gtk::Label>("p_apply_info_text", builder) },
+    p_profile_info{ Common::get_widget_shared<Gtk::Box>("p_profile_info", builder) },
+    p_num_log_label{ Common::get_widget_shared<Gtk::Label>("p_num_log_label", builder) },
+    p_num_proc_label{ Common::get_widget_shared<Gtk::Label>("p_num_proc_label", builder) },
+    p_num_perm_label{ Common::get_widget_shared<Gtk::Label>("p_num_perm_label", builder) },
     loader{ new ProfileLoader() }
 {
   // Add tabs to the stack pane

--- a/src/tabs/view/profiles.h
+++ b/src/tabs/view/profiles.h
@@ -64,10 +64,6 @@ private:
   // Profile Loader page, which is added to the stack
   std::unique_ptr<ProfileLoader> loader;
 
-  // Misc
-  template<typename T_Widget>
-  static std::shared_ptr<T_Widget> get_widget_shared(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);
-
 #ifdef TESTS_ENABLED
   FRIEND_TEST(ProfilesTest, CHECK_APPLY_LABEL_TEXT);
   FRIEND_TEST(ProfilesTest, CHANGE_STATUS_WIDGETS_INVISIBLE_WHEN_NO_ROWS_SELECTED);

--- a/src/tabs/view/profiles.h
+++ b/src/tabs/view/profiles.h
@@ -47,19 +47,19 @@ private:
   // Widgets
   Glib::RefPtr<Gtk::Builder> builder;
 
-  std::shared_ptr<Gtk::ToggleButton> p_change_state_toggle;
-  std::shared_ptr<Gtk::ToggleButton> p_load_profile_toggle;
+  std::unique_ptr<Gtk::ToggleButton> p_change_state_toggle;
+  std::unique_ptr<Gtk::ToggleButton> p_load_profile_toggle;
 
-  std::shared_ptr<Gtk::Stack> p_stack;
-  std::shared_ptr<Gtk::Box> p_state_selection_box;
-  std::shared_ptr<Gtk::ComboBoxText> p_status_selection;
-  std::shared_ptr<Gtk::Button> p_apply_button;
-  std::shared_ptr<Gtk::Label> p_apply_info_text;
+  std::unique_ptr<Gtk::Stack> p_stack;
+  std::unique_ptr<Gtk::Box> p_state_selection_box;
+  std::unique_ptr<Gtk::ComboBoxText> p_status_selection;
+  std::unique_ptr<Gtk::Button> p_apply_button;
+  std::unique_ptr<Gtk::Label> p_apply_info_text;
 
-  std::shared_ptr<Gtk::Box> p_profile_info;
-  std::shared_ptr<Gtk::Label> p_num_log_label;
-  std::shared_ptr<Gtk::Label> p_num_proc_label;
-  std::shared_ptr<Gtk::Label> p_num_perm_label;
+  std::unique_ptr<Gtk::Box> p_profile_info;
+  std::unique_ptr<Gtk::Label> p_num_log_label;
+  std::unique_ptr<Gtk::Label> p_num_proc_label;
+  std::unique_ptr<Gtk::Label> p_num_perm_label;
 
   // Profile Loader page, which is added to the stack
   std::unique_ptr<ProfileLoader> loader;

--- a/src/tabs/view/status.cc
+++ b/src/tabs/view/status.cc
@@ -1,3 +1,4 @@
+#include "common.h"
 #include "status.h"
 
 #include "jsoncpp/json/json.h"
@@ -6,22 +7,6 @@
 #include <regex>
 #include <sstream>
 #include <string>
-
-template<typename T_Widget>
-std::unique_ptr<T_Widget> Status::get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder)
-{
-  T_Widget *raw_addr = nullptr;
-  builder->get_widget<T_Widget>(name, raw_addr);
-  return std::unique_ptr<T_Widget>(raw_addr);
-}
-
-template<typename T_Widget>
-std::shared_ptr<T_Widget> Status::get_widget_shared(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder)
-{
-  T_Widget *raw_addr = nullptr;
-  builder->get_widget<T_Widget>(name, raw_addr);
-  return std::shared_ptr<T_Widget>(raw_addr);
-}
 
 void Status::set_status_label_text(const std::string &str)
 {
@@ -73,15 +58,15 @@ void Status::show_searchbar(const bool &should_focus)
 
 Status::Status(const std::string &glade_resource)
   : builder{ Gtk::Builder::create_from_resource(glade_resource) },
-    s_view{ Status::get_widget_shared<Gtk::TreeView>("s_view", builder) },
-    s_win{ Status::get_widget_shared<Gtk::ScrolledWindow>("s_win", builder) },
-    s_box{ Status::get_widget<Gtk::Box>("s_box", builder) },
-    s_searchbox{ Status::get_widget<Gtk::Box>("s_searchbox", builder) },
-    s_search{ Status::get_widget<Gtk::SearchEntry>("s_search", builder) },
-    s_use_regex{ Status::get_widget<Gtk::CheckButton>("s_use_regex", builder) },
-    s_match_case{ Status::get_widget<Gtk::CheckButton>("s_match_case", builder) },
-    s_whole_word{ Status::get_widget<Gtk::CheckButton>("s_whole_word", builder) },
-    s_found_label{ Status::get_widget<Gtk::Label>("s_found_label", builder) }
+    s_view{ Common::get_widget_shared<Gtk::TreeView>("s_view", builder) },
+    s_win{ Common::get_widget_shared<Gtk::ScrolledWindow>("s_win", builder) },
+    s_box{ Common::get_widget<Gtk::Box>("s_box", builder) },
+    s_searchbox{ Common::get_widget<Gtk::Box>("s_searchbox", builder) },
+    s_search{ Common::get_widget<Gtk::SearchEntry>("s_search", builder) },
+    s_use_regex{ Common::get_widget<Gtk::CheckButton>("s_use_regex", builder) },
+    s_match_case{ Common::get_widget<Gtk::CheckButton>("s_match_case", builder) },
+    s_whole_word{ Common::get_widget<Gtk::CheckButton>("s_whole_word", builder) },
+    s_found_label{ Common::get_widget<Gtk::Label>("s_found_label", builder) }
 {
   s_view->set_activate_on_single_click(true);
 

--- a/src/tabs/view/status.cc
+++ b/src/tabs/view/status.cc
@@ -1,5 +1,5 @@
-#include "common.h"
 #include "status.h"
+#include "common.h"
 
 #include "jsoncpp/json/json.h"
 

--- a/src/tabs/view/status.h
+++ b/src/tabs/view/status.h
@@ -53,9 +53,7 @@ public:
   void set_refresh_signal_handler(const Glib::SignalProxyProperty::SlotType &func);
 
   SearchInfo get_search_info();
-
   void hide_searchbar();
-
   void show_searchbar(const bool &should_focus);
 
 protected:
@@ -79,12 +77,6 @@ private:
   std::unique_ptr<Gtk::CheckButton> s_match_case;
   std::unique_ptr<Gtk::CheckButton> s_whole_word;
   std::unique_ptr<Gtk::Label> s_found_label;
-
-  // Misc
-  template<typename T_Widget>
-  static std::shared_ptr<T_Widget> get_widget_shared(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);
-  template<typename T_Widget>
-  static std::unique_ptr<T_Widget> get_widget(Glib::ustring name, const Glib::RefPtr<Gtk::Builder> &builder);
 
   // clang-tidy complains about the `COLUMN_TYPE_STRING` macro, so we assign it here and tell clang-tidy not to look at it
   static constexpr unsigned int COLUMN_TYPE_STRING = G_TYPE_STRING; // NOLINT


### PR DESCRIPTION
This is a simple PR which cleans code by moving the `get_widget` and `get_widget_shared` functions to a separate class. Previously, there were copies of this function repeated in multiple classes. This fixes that.