### PR TITLE
Audit mode

### DIFF
--- a/resources/profile.glade
+++ b/resources/profile.glade
@@ -388,7 +388,8 @@
             <items>
               <item id="combo_enforce" translatable="yes">Enforce</item>
               <item id="combo_complain" translatable="yes">Complain</item>
-              <item id="combo_unconfine" translatable="yes">Disabled</item>
+              <item id="combo_audit" translatable="yes">Audit</item>
+              <item id="combo_unconfined" translatable="yes">Disabled</item>
             </items>
             <child internal-child="entry">
               <object class="GtkEntry">

--- a/src/tabs/controller/logs_controller.cc
+++ b/src/tabs/controller/logs_controller.cc
@@ -79,8 +79,8 @@ void LogsController<LogsTab, Database, Adapter>::add_row_from_json(const Json::V
     std::string status = format_log_data(entry["_AUDIT_FIELD_PROFILE"].asString());
     metadata.push_back({ "Status", status });
   }
-  /* Denied access event */
-  else if (type == "DENIED") {
+  /* Either the Denied or Audited access event */
+  else if (type == "DENIED" || type == "AUDIT") {
     name      = format_log_data(entry["_AUDIT_FIELD_PROFILE"].asString());
     operation = format_log_data(entry["_AUDIT_FIELD_OPERATION"].asString());
 
@@ -108,10 +108,6 @@ void LogsController<LogsTab, Database, Adapter>::add_row_from_json(const Json::V
   // else if(type == "ERROR") {
 
   // }
-  // /* Audited event */
-  // else if(type == "AUDIT") {
-
-  // }
   // /* Complain mode event */
   // else if(type == "ALLOWED") {
 
@@ -121,7 +117,7 @@ void LogsController<LogsTab, Database, Adapter>::add_row_from_json(const Json::V
 
   // }
   else {
-    std::cerr << "Error - Unknown log type: " << type << std::endl;
+    std::cerr << "Error - Unknown log type (" << type << ") : " << entry << std::endl;
     name      = entry["_AUDIT_FIELD_NAME"].asString();
     operation = format_log_data(entry["_AUDIT_FIELD_OPERATION"].asString());
 

--- a/src/tabs/controller/processes_controller.cc
+++ b/src/tabs/controller/processes_controller.cc
@@ -12,7 +12,7 @@
 const std::regex unconfined_proc("^\\s*(\\S+)\\s+(\\S+)\\s+(\\S+)\\s+(unconfined|\\S+ \\(\\S+\\))\\s+(\\S+)"); // NOLINT(cert-err58-cpp)
 
 // TODO(regex): This is pretty buggy currently, we should fix it
-const std::regex confined_prof("^\\s*(.+)\\s+\\((enforce|complain)\\)"); // NOLINT(cert-err58-cpp)
+const std::regex confined_prof("^\\s*(.+)\\s+\\((enforce|complain|audit)\\)"); // NOLINT(cert-err58-cpp)
 
 template<class ProcessesTab, class Database, class Adapter>
 void ProcessesController<ProcessesTab, Database, Adapter>::add_row_from_line(const std::string &line)

--- a/src/tabs/model/profile_adapter.cc
+++ b/src/tabs/model/profile_adapter.cc
@@ -27,6 +27,8 @@ void ProfileAdapter<Database>::put_data(const std::string &profile_name, const s
     // A pre-existing entry was found, so we should modify it
     ProfileTableEntry entry = iter->second;
     entry.status            = status;
+    entry.row->set_value(2, status);
+
     db->profile_data.erase(profile_name);
     db->profile_data.insert({ profile_name, entry });
   }

--- a/src/tabs/view/profiles.cc
+++ b/src/tabs/view/profiles.cc
@@ -27,8 +27,8 @@ void Profiles::change_status()
     // Get the status that we intend to switch to
     std::string new_status = p_status_selection->get_active_text();
 
-    row->get_value(0, profile_path);
-    row->get_value(1, old_status);
+    row->get_value(1, profile_path);
+    row->get_value(2, old_status);
 
     // Convert the status strings to lower case.
     transform(old_status.begin(), old_status.end(), old_status.begin(), ::tolower);

--- a/src/threads/command_caller.cc
+++ b/src/threads/command_caller.cc
@@ -94,14 +94,16 @@ std::string CommandCaller::execute_change(CommandCaller *caller,
 {
   std::string status_command;
 
-  if (new_status == "enforce" && old_status != "enforce") {
-    status_command = "aa-enforce";
-  } else if (new_status == "complain" && old_status != "complain") {
-    status_command = "aa-complain";
-  } else if (new_status == "disable" && old_status != "disabled") {
-    status_command = "aa-disable";
-  } else if (new_status == old_status) {
+  if (new_status == old_status) {
     return "'" + profile + "' already set to " + new_status + ".";
+  } else if (new_status == "enforce") {
+    status_command = "aa-enforce";
+  } else if (new_status == "complain") {
+    status_command = "aa-complain";
+  } else if (new_status == "audit") {
+    status_command = "aa-audit";
+  } else if (new_status == "disabled") {
+    status_command = "aa-disable";
   } else {
     return "Error: Illegal arguments passed to CommandCaller::execute_change.";
   }

--- a/test/src/tabs/view/profiles_test.cc
+++ b/test/src/tabs/view/profiles_test.cc
@@ -10,11 +10,13 @@ using ::testing::_;
 
 Glib::RefPtr<Gtk::TreeStore> ProfilesTest::initialize_store()
 {
-  auto first_column  = Gtk::TreeModelColumn<std::string>();
+  auto first_column  = Gtk::TreeModelColumn<ProfileTableEntry>();
   auto second_column = Gtk::TreeModelColumn<std::string>();
+  auto third_column  = Gtk::TreeModelColumn<std::string>();
 
   record.add(first_column);
   record.add(second_column);
+  record.add(third_column);
 
   auto view = pc.get_view();
   EXPECT_FALSE(view == nullptr) << "`pc.get_view()` should not return a nullptr";
@@ -32,8 +34,8 @@ void ProfilesTest::create_and_select_row(Glib::RefPtr<Gtk::TreeStore> store, std
 {
   // Create a row and put some data into the first column
   auto iter = store->append();
-  iter->set_value(0, profile);
-  iter->set_value(1, status);
+  iter->set_value(1, profile);
+  iter->set_value(2, status);
 
   // Get the path to the newly created row
   auto path = store->get_path(iter);

--- a/test/src/tabs/view/profiles_test.h
+++ b/test/src/tabs/view/profiles_test.h
@@ -1,8 +1,8 @@
 #ifndef TEST_SRC_TABS_CONTROLLER_PROFILES_MOCK_TEST_H
 #define TEST_SRC_TABS_CONTROLLER_PROFILES_MOCK_TEST_H
 
-#include "../../../../src/tabs/view/profiles.h"
 #include "../../../../src/tabs/entries.h"
+#include "../../../../src/tabs/view/profiles.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>

--- a/test/src/tabs/view/profiles_test.h
+++ b/test/src/tabs/view/profiles_test.h
@@ -2,6 +2,7 @@
 #define TEST_SRC_TABS_CONTROLLER_PROFILES_MOCK_TEST_H
 
 #include "../../../../src/tabs/view/profiles.h"
+#include "../../../../src/tabs/entries.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>


### PR DESCRIPTION
### Description
This PR allows the user to switch an AppArmor profile to _Audit_ mode. According to AppArmor developers, this confinement mode should only be used sparingly, most likely because it can pollute the system logs with unimportant data. We might want to communicate this to the users somehow.

The [AppArmor wiki](https://gitlab.com/apparmor/apparmor/-/wikis/manpage_aa-audit.8#description) explains the functionality for this confinement mode: "In this mode security policy is enforced and all access (successes and failures) are logged to the system log"

#### Change 1 - Fix error preventing changing a profiles status
I found a few regressions that were not caught by the unit tests, which prevented the user from correctly changing a profiles status. This PR should fix those bugs

#### Change 2 - Add ability to change profile to _Audit_ mode
This was pretty simple, and involved making a call to `aa-enforce`

#### Change 3 - Correctly parse 'Audit' logs
Previously, AppArmor logs with type 'Audit' were not correctly parsed by the application. These changes should fix that. 