### PR TITLE
Support for modifying Snaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,11 +184,24 @@ set(CPACK_PACKAGE_CONTACT "Jack Ullery")
 set(CPACK_INSTALL_SCRIPT "cmake_install.cmake")
 include(CPack)
 
-#### Create install target to modify pkexec ####
+#### Set install target to also modify pkexec ####
 install(
   FILES ${PKEXEC_POLICY}
   DESTINATION /usr/share/polkit-1/actions/
 )
+
+#### Set install target to make snap profiles modifiable ####
+# This creates symbolic links in `/var/lib/snapd/apparmor/profiles`, to make it easier to modify these profiles
+
+set(PROFILE_SUBDIRS abi abstractions disable force-complain local tunables)
+foreach(SUBDIR ${PROFILE_SUBDIRS})
+  install(CODE "execute_process(
+    COMMAND bash -c \"
+      test -d /var/lib/snapd/apparmor/profiles &&
+      ! (test -d /var/lib/snapd/apparmor/profiles/${SUBDIR}) &&
+      sudo ln -s /etc/apparmor.d/${SUBDIR} /var/lib/snapd/apparmor/profiles
+    \")")
+endforeach( SUBDIR )
 
 #### Creating uninstall target (copying code from CMake FAQ) ####
 if(NOT TARGET uninstall)


### PR DESCRIPTION
Previously, there would be errors when changing the confinement of an AppArmor profile for a snap. This was because these profiles are at `/var/lib/snapd/apparmor/profiles`, which is not the default place for AppArmor profiles.

I updated _CommandCaller_, to also look for profiles in this location, before attempting to change their status, and modifying the command appropriately. 

Furthermore, I set the CMake script to add a few symbolic links to the `/var/lib/snapd/apparmor/profiles` directory, to help ensure that future calls to aa-enforce, aa-complain, etc would be successful. If I did not do this, then there would not be the subdirectory `abstractions` in `/var/lib/snapd/apparmor/profiles`, and aa-enforce would fail when attempting to change a snap profile's confinement