### PR TITLE
Read logs from auditd

### DIFF
--- a/aa-caller/src/aa-caller.cc
+++ b/aa-caller/src/aa-caller.cc
@@ -1,12 +1,21 @@
 #include "aa-caller.h"
 
+#include <cstdlib>
 #include <glibmm/spawn.h>
 #include <iostream>
 
 AppArmorCaller::results AppArmorCaller::call_command(const std::vector<std::string> &command)
 {
   results result;
-  Glib::spawn_sync("/usr/sbin/", command, Glib::SpawnFlags::SPAWN_SEARCH_PATH, {}, &result.output, &result.error, &result.exit_status);
+  std::vector<std::string> envp = {"/usr/bin/", "/usr/sbin/"};
+  Glib::spawn_sync("/usr/sbin/",
+                   command,
+                   envp,
+                   Glib::SpawnFlags::SPAWN_SEARCH_PATH_FROM_ENVP,
+                   {},
+                   &result.output,
+                   &result.error,
+                   &result.exit_status);
   return result;
 }
 
@@ -18,9 +27,14 @@ std::string AppArmorCaller::call_command(const std::vector<std::string> &command
 
   results result = call_command(command);
 
+  // If there was an error, print it out to std::cerr
   if (result.exit_status != 0) {
-    std::cout << "Error calling '" << command[0] << "'. " << result.error << std::endl;
-    return return_on_error;
+    // ausearch returns and error code if no data was found
+    // I do not consider that an issue, so I suppress it here
+    if(command[0] != "ausearch" || result.exit_status != 256) {
+      std::cerr << "Error calling '" << command[0] << "' returned (" << result.exit_status << "). " << result.error << std::endl;
+      return return_on_error;
+    }
   }
 
   return result.output;
@@ -40,6 +54,14 @@ std::string AppArmorCaller::get_unconfined(AppArmorCaller *caller)
   return caller->call_command(command, return_on_error);
 }
 
+std::string AppArmorCaller::get_logs(AppArmorCaller *caller, const std::string &filename)
+{
+  std::vector<std::string> command = {"ausearch", "--raw", "-m", "AVC", "--checkpoint", filename};
+
+  std::string return_on_error;
+  return caller->call_command(command, return_on_error);
+}
+
 // Static public methods
 std::string AppArmorCaller::get_status()
 {
@@ -51,4 +73,25 @@ std::string AppArmorCaller::get_unconfined()
 {
   AppArmorCaller caller;
   return get_unconfined(&caller);
+}
+
+std::string AppArmorCaller::get_logs()
+{
+  AppArmorCaller caller;
+
+  // Create a random filename with the following format '/tmp/appanvil-$RAND' 
+  std::stringstream stream;
+  stream << "/tmp/appanvil-" << rand();
+
+  // Call get_logs and append the output to what we are interested in
+  std::string output = get_logs(&caller, stream.str());
+  stream << std::endl << output;
+
+  return stream.str();
+}
+
+std::string AppArmorCaller::get_logs(const std::string &filename)
+{
+  AppArmorCaller caller;
+  return get_logs(&caller, filename);
 }

--- a/aa-caller/src/aa-caller.cc
+++ b/aa-caller/src/aa-caller.cc
@@ -79,6 +79,9 @@ std::string AppArmorCaller::get_logs()
 {
   AppArmorCaller caller;
 
+  // Seed the random number generator using the time
+  srand(time(NULL));
+
   // Create a random filename with the following format '/tmp/appanvil-$RAND' 
   std::stringstream stream;
   stream << "/tmp/appanvil-" << rand();

--- a/aa-caller/src/aa-caller.cc
+++ b/aa-caller/src/aa-caller.cc
@@ -7,15 +7,9 @@
 AppArmorCaller::results AppArmorCaller::call_command(const std::vector<std::string> &command)
 {
   results result;
-  std::vector<std::string> envp = {"/usr/bin/", "/usr/sbin/"};
-  Glib::spawn_sync("/usr/sbin/",
-                   command,
-                   envp,
-                   Glib::SpawnFlags::SPAWN_SEARCH_PATH_FROM_ENVP,
-                   {},
-                   &result.output,
-                   &result.error,
-                   &result.exit_status);
+  std::vector<std::string> envp = { "/usr/bin/", "/usr/sbin/" };
+  Glib::spawn_sync(
+    "/usr/sbin/", command, envp, Glib::SpawnFlags::SPAWN_SEARCH_PATH_FROM_ENVP, {}, &result.output, &result.error, &result.exit_status);
   return result;
 }
 
@@ -31,7 +25,7 @@ std::string AppArmorCaller::call_command(const std::vector<std::string> &command
   if (result.exit_status != 0) {
     // ausearch returns and error code if no data was found
     // I do not consider that an issue, so I suppress it here
-    if(command[0] != "ausearch" || result.exit_status != 256) {
+    if (command[0] != "ausearch" || result.exit_status != 256) {
       std::cerr << "Error calling '" << command[0] << "' returned (" << result.exit_status << "). " << result.error << std::endl;
       return return_on_error;
     }
@@ -56,7 +50,7 @@ std::string AppArmorCaller::get_unconfined(AppArmorCaller *caller)
 
 std::string AppArmorCaller::get_logs(AppArmorCaller *caller, const std::string &filename)
 {
-  std::vector<std::string> command = {"ausearch", "--raw", "-m", "AVC", "--checkpoint", filename};
+  std::vector<std::string> command = { "ausearch", "--raw", "-m", "AVC", "--checkpoint", filename };
 
   std::string return_on_error;
   return caller->call_command(command, return_on_error);
@@ -82,7 +76,7 @@ std::string AppArmorCaller::get_logs()
   // Seed the random number generator using the time
   srand(time(NULL));
 
-  // Create a random filename with the following format '/tmp/appanvil-$RAND' 
+  // Create a random filename with the following format '/tmp/appanvil-$RAND'
   std::stringstream stream;
   stream << "/tmp/appanvil-" << rand();
 

--- a/aa-caller/src/aa-caller.h
+++ b/aa-caller/src/aa-caller.h
@@ -42,6 +42,28 @@ public:
    */
   static std::string get_unconfined();
 
+  /**
+   * @brief Return the output of `ausearch`
+   *
+   * @details
+   * Returns the output of `pkexec ausearch --raw -m AVC --checkpoint [filename]` to get a list of logs that may pertain to AppArmor,
+   * where [filename] is a randomly named checkpoint file in /tmp.
+   *
+   * @returns std::string the raw output of ausearch, prepended by [filename]
+   */
+  static std::string get_logs();
+
+  /**
+   * @brief Return the output of `ausearch`
+   *
+   * @details
+   * Returns the output of `pkexec ausearch --raw -m AVC --checkpoint [filename]` to get a list of logs that may pertain to AppArmor,
+   * where [filename] is the argument to the method.
+   *
+   * @returns std::string the raw output of ausearch
+   */
+  static std::string get_logs(const std::string &filename);
+
 protected:
   struct results
   {
@@ -57,6 +79,7 @@ protected:
   // Dependency Injection: For unit testing
   static std::string get_status(AppArmorCaller *caller);
   static std::string get_unconfined(AppArmorCaller *caller);
+  static std::string get_logs(AppArmorCaller *caller, const std::string &filename);
 };
 
 #endif // COMMAND_CALLER_H

--- a/aa-caller/src/main.cc
+++ b/aa-caller/src/main.cc
@@ -4,11 +4,14 @@
 
 void print_usage()
 {
-  std::cout << "A utility to do common AppArmor tasks (used by the AppAnvil Project)" << std::endl << std::endl;
+  std::cout << "A utility to do common AppArmor tasks (used internally by the AppAnvil Project)" << std::endl;
+  std::cout << "This tool is not intended for direct use by the end-user" << std::endl << std::endl;
   std::cout << "Usage: aa-caller <option>" << std::endl << std::endl;
   std::cout << "Options:" << std::endl;
   std::cout << "   -s :  call \"aa-status\", to get the status of currently confined apps" << std::endl;
   std::cout << "   -u :  call \"aa-unconfined\", to get the status of some unconfined apps" << std::endl;
+  std::cout << "   -l :  call \"ausearch\", to get auditd logs. First line of output is a randomly-named checkpoint file." << std::endl;
+  std::cout << "   -l [filename]:  call \"ausearch\", to get auditd logs, using a previously generated checkpoint file." << std::endl;
 }
 
 int main(int argc, char **argv)
@@ -25,6 +28,21 @@ int main(int argc, char **argv)
     if (arg == "-u") {
       // Argument for: "get_unconfined"
       std::cout << AppArmorCaller::get_unconfined();
+      return 0;
+    }
+
+    if (arg == "-l") {
+      // Argument for: "get_logs"
+      std::cout << AppArmorCaller::get_logs();
+      return 0;
+    }
+  }
+  else if (argc == 3) {
+    std::string arg_1(argv[1]);
+    std::string arg_2(argv[2]);
+    if (arg_1 == "-l") {
+      // Argument for: "get_logs"
+      std::cout << AppArmorCaller::get_logs(arg_2);
       return 0;
     }
   }

--- a/aa-caller/src/main.cc
+++ b/aa-caller/src/main.cc
@@ -36,8 +36,7 @@ int main(int argc, char **argv)
       std::cout << AppArmorCaller::get_logs();
       return 0;
     }
-  }
-  else if (argc == 3) {
+  } else if (argc == 3) {
     std::string arg_1(argv[1]);
     std::string arg_2(argv[2]);
     if (arg_1 == "-l") {

--- a/resources/com.github.jack-ullery.AppAnvil.pkexec.policy
+++ b/resources/com.github.jack-ullery.AppAnvil.pkexec.policy
@@ -10,7 +10,8 @@
     <defaults>
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/local/bin/aa-caller</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/aa-caller</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/bin/aa-caller</annotate>
   </action>
 
 </policyconfig>

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -136,7 +136,6 @@ bool MainWindow::on_switch(GdkEvent *event)
   } else if (visible_child == "proc") {
     console->send_refresh_message(PROCESS);
   } else if (visible_child == "logs") {
-    // Do not refresh logs (until improved)
     console->send_refresh_message(LOGS);
   }
 

--- a/src/threads/command_caller.cc
+++ b/src/threads/command_caller.cc
@@ -10,15 +10,9 @@
 CommandCaller::results CommandCaller::call_command(const std::vector<std::string> &command)
 {
   results result;
-  std::vector<std::string> envp = {"/usr/bin/", "/usr/sbin/", "/usr/local/bin"};
-  Glib::spawn_sync("/usr/sbin/",
-                   command,
-                   envp,
-                   Glib::SpawnFlags::SPAWN_SEARCH_PATH_FROM_ENVP,
-                   {},
-                   &result.output,
-                   &result.error,
-                   &result.exit_status);
+  std::vector<std::string> envp = { "/usr/bin/", "/usr/sbin/", "/usr/local/bin" };
+  Glib::spawn_sync(
+    "/usr/sbin/", command, envp, Glib::SpawnFlags::SPAWN_SEARCH_PATH_FROM_ENVP, {}, &result.output, &result.error, &result.exit_status);
   return result;
 }
 
@@ -54,9 +48,9 @@ std::string CommandCaller::get_unconfined(CommandCaller *caller)
 
 std::string CommandCaller::get_logs(CommandCaller *caller, const std::string &checkpoint_filepath)
 {
-  std::vector<std::string> command = {"pkexec", "aa-caller", "-l"};
+  std::vector<std::string> command = { "pkexec", "aa-caller", "-l" };
 
-  if(!checkpoint_filepath.empty()) {
+  if (!checkpoint_filepath.empty()) {
     command.push_back(checkpoint_filepath);
   }
 

--- a/src/threads/command_caller.h
+++ b/src/threads/command_caller.h
@@ -29,24 +29,43 @@ public:
   CommandCaller &operator=(CommandCaller &&)      = delete;
 
   /**
-   * @brief Return the output of `aa-status --json`
+   * @brief Return the output of `aa-caller -s`
    *
    * @details
-   * Returns the output of `pkexec aa-status --json` to get a list of profiles and processes confined by apparmor.
+   * Uses aa-caller, to call aa-status to get a list of profiles and processes confined by apparmor.
+   *
+   * Wrapping this call in aa-caller ensures that the user does not need to authenticate
+   * to pkexec every few seconds.
    *
    * @returns std::string the raw output of aa-status
    */
   static std::string get_status();
 
   /**
-   * @brief Return the output of `aa-unconfined`
+   * @brief Return the output of `aa-caller -u`
    *
    * @details
-   * Returns the output of `pkexec aa-unconfined` to get a list of processes not confined by apparmor.
+   * Uses aa-caller, to call aa-unconfined to get a list of processes not confined by apparmor.
+   *
+   * Wrapping this call in aa-caller ensures that the user does not need to authenticate
+   * to pkexec every few seconds.
    *
    * @returns std::string the raw output of aa-unconfined
    */
   static std::string get_unconfined();
+
+  /**
+   * @brief Return the output of `aa-caller -l`
+   *
+   * @details
+   * Uses aa-caller which calls ausearch to get a list of logs that may pertain to AppArmor.
+   *
+   * Wrapping this call in aa-caller ensures that the user does not need to authenticate
+   * to pkexec every few seconds.
+   *
+   * @returns std::string the raw output of ausearch
+   */
+  static std::string get_logs(const std::string &checkpoint_filepath);
 
   /**
    * @brief Change the status of a profile
@@ -96,6 +115,7 @@ protected:
   // Dependency Injection: For unit testing
   static std::string get_status(CommandCaller *caller);
   static std::string get_unconfined(CommandCaller *caller);
+  static std::string get_logs(CommandCaller *caller, const std::string &checkpoint_filepath);
   static std::string load_profile(CommandCaller *caller, const std::string &fullFileName);
   static std::string disable_profile(CommandCaller *caller, const std::string &profileName);
   static std::string execute_change(CommandCaller *caller,

--- a/src/threads/log_reader.cc
+++ b/src/threads/log_reader.cc
@@ -1,5 +1,8 @@
+#include "command_caller.h"
 #include "log_reader.h"
 #include "log_record.h"
+
+#include <sstream>
 
 LogReader::LogReader(const std::initializer_list<std::string> &log_sources)
 {
@@ -23,5 +26,26 @@ std::list<std::shared_ptr<LogRecord>> LogReader::read_logs()
     }
   }
 
+  append_audit_logs(logs);
   return logs;
+}
+
+void LogReader::append_audit_logs(std::list<std::shared_ptr<LogRecord>> &log_list)
+{
+  std::string output = CommandCaller::get_logs(checkpoint_filepath);
+  std::istringstream stream(output);
+
+  if(checkpoint_filepath.empty()) {
+    std::getline(stream, checkpoint_filepath);
+  }
+
+  std::string line;
+  while (std::getline(stream, line))
+  {
+    auto log = std::make_shared<LogRecord>(line);
+
+    if(log->valid()) {
+      log_list.push_back(log);
+    }
+  }
 }

--- a/src/threads/log_reader.cc
+++ b/src/threads/log_reader.cc
@@ -1,5 +1,5 @@
-#include "command_caller.h"
 #include "log_reader.h"
+#include "command_caller.h"
 #include "log_record.h"
 
 #include <sstream>
@@ -35,16 +35,15 @@ void LogReader::append_audit_logs(std::list<std::shared_ptr<LogRecord>> &log_lis
   std::string output = CommandCaller::get_logs(checkpoint_filepath);
   std::istringstream stream(output);
 
-  if(checkpoint_filepath.empty()) {
+  if (checkpoint_filepath.empty()) {
     std::getline(stream, checkpoint_filepath);
   }
 
   std::string line;
-  while (std::getline(stream, line))
-  {
+  while (std::getline(stream, line)) {
     auto log = std::make_shared<LogRecord>(line);
 
-    if(log->valid()) {
+    if (log->valid()) {
       log_list.push_back(log);
     }
   }

--- a/src/threads/log_reader.h
+++ b/src/threads/log_reader.h
@@ -15,8 +15,13 @@ public:
 
   std::list<std::shared_ptr<LogRecord>> read_logs();
 
+protected:
+  // Append logs from ausearch to list
+  void append_audit_logs(std::list<std::shared_ptr<LogRecord>> &log_list);
+
 private:
   std::forward_list<std::ifstream> log_files;
+  std::string checkpoint_filepath;
 };
 
 #endif


### PR DESCRIPTION
This allows AppAnvil to read additional logs from auditd.

### Changes

#### Add flag to `aa-caller`
Added a flag "-l" to aa-caller. When `aa-caller -l` is executed, it calls ausearch to return a list of logs that may pertain to apparmor. Some of the logs might not be apparmor related. 

Furthermore, this generates a randomly named checkpoint file that ausearch can use to save progress. The file's name has the following format: `/tmp/appanvil_[random]`, where [random] is a random number. This filename is printed on the first line of output from aa-caller. Afterwards, the user can execute `aa-caller -l [filename]` to get any new logs. See the _checkpoint_ option in `man ausearch` for more information.

#### Use `aa-caller` when reading logs
Now the _LogReader_ class also queries aa-caller when reading logs. So that they are shown in AppAnvil.

#### Minor changes to pkexec policy
I noticed that the pkexec policy does not actually point to the final installed location of aa-caller. I fixed that in this update. Ideally, we should configure that location automatically when CMake is called.

### Possible issues
It may be possible for auditd and sysog to store duplicate entries for the same event. This would show as duplicate entries in AppAnvil.

Like I said earlier, I should probably configure the pkexec policy dynamically when CMake is built. 