### PR TITLE
Change status

### DIFF
--- a/resources/profile.glade
+++ b/resources/profile.glade
@@ -2,11 +2,6 @@
 <!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkImage" id="change_status_icon">
-    <property name="visible">True</property>
-    <property name="can-focus">False</property>
-    <property name="icon-name">system-lock-screen</property>
-  </object>
   <object class="GtkImage" id="load_profile_icon">
     <property name="visible">True</property>
     <property name="can-focus">False</property>
@@ -133,26 +128,6 @@
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToggleButton" id="p_change_state_toggle">
-                    <property name="label" translatable="yes"> Change Confinement</property>
-                    <property name="width-request">100</property>
-                    <property name="visible">True</property>
-                    <property name="app-paintable">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">True</property>
-                    <property name="halign">center</property>
-                    <property name="margin-top">10</property>
-                    <property name="image">change_status_icon</property>
-                    <property name="always-show-image">True</property>
-                    <property name="draw-indicator">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
@@ -348,75 +323,6 @@
         <property name="expand">False</property>
         <property name="fill">True</property>
         <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkBox" id="p_state_selection_box">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="margin-start">10</property>
-        <property name="margin-end">10</property>
-        <child>
-          <object class="GtkComboBoxText" id="p_status_selection">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-start">10</property>
-            <property name="has-entry">True</property>
-            <items>
-              <item id="combo_enforce" translatable="yes">Enforce</item>
-              <item id="combo_complain" translatable="yes">Complain</item>
-              <item id="combo_audit" translatable="yes">Audit</item>
-              <item id="combo_unconfined" translatable="yes">Disabled</item>
-            </items>
-            <child internal-child="entry">
-              <object class="GtkEntry">
-                <property name="can-focus">True</property>
-                <property name="text" translatable="yes">Disabled</property>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="p_apply_button">
-            <property name="label" translatable="yes">Apply</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="margin-start">5</property>
-            <property name="margin-end">10</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkLabel" id="p_apply_info_text">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-start">15</property>
-            <property name="margin-end">5</property>
-            <property name="wrap">True</property>
-            <property name="selectable">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">4</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">False</property>
-        <property name="padding">8</property>
-        <property name="position">2</property>
       </packing>
     </child>
     <child>

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -1,4 +1,5 @@
 #include "main_window.h"
+#include "console_thread.h"
 
 #include <gtkmm/button.h>
 #include <gtkmm/enums.h>
@@ -31,8 +32,8 @@ MainWindow::MainWindow()
   on_switch(NULL);
 
   // Connect the profile tab to the `send_status_change` method
-  auto change_fun = sigc::mem_fun(*this, &MainWindow::send_status_change);
-  prof_control->get_tab()->set_status_change_signal_handler(change_fun);
+  auto change_fun = sigc::mem_fun(*console, &ConsoleThreadInstance::send_change_profile_status_message);
+  prof_control->set_status_change_signal_handler(change_fun);
 
   // Configure settings related to the 'Help' button
   m_help_button.set_image_from_icon_name("dialog-question");
@@ -80,11 +81,6 @@ MainWindow::MainWindow()
 
   // Hide the side info in the Profiles Tab
   prof_control->get_tab()->hide_profile_info();
-}
-
-void MainWindow::send_status_change(const std::string &profile, const std::string &old_status, const std::string &new_status)
-{
-  console->send_change_profile_status_message(profile, old_status, new_status);
 }
 
 void MainWindow::on_help_toggle()

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -66,8 +66,6 @@ protected:
    */
   bool on_switch(GdkEvent *event);
 
-  void send_status_change(const std::string &profile, const std::string &old_status, const std::string &new_status);
-
 private:
   // A set of Typedeffed classes, to handle dependency injection
   // This lowers the amount of repeated <..> symbols

--- a/src/tabs/controller/profile_modify_controller.cc
+++ b/src/tabs/controller/profile_modify_controller.cc
@@ -50,9 +50,6 @@ void ProfileModifyController::intialize_file_rules()
     row->set_value(FILE_RULE_POS::Lock, filemode.getLock());
     row->set_value(FILE_RULE_POS::Exec, exec_allowed);
     row->set_value(FILE_RULE_POS::Exec_Type, filemode.getExecuteMode());
-
-    auto change_fun = sigc::mem_fun(*this, &ProfileModifyController::handle_file_rule_changed);
-    file_rule_record->set_change_func(change_fun);
   }
 }
 
@@ -144,5 +141,8 @@ ProfileModifyController::ProfileModifyController(std::shared_ptr<AppArmor::Parse
     abstraction_record{ StatusColumnRecord::create(modify->get_abstraction_view(), abstraction_col_names) },
     file_rule_record{ StatusColumnRecord::create(modify->get_file_rule_view(), file_rule_col_names) }
 {
+  auto change_fun = sigc::mem_fun(*this, &ProfileModifyController::handle_file_rule_changed);
+  file_rule_record->set_change_func(change_fun);
+
   update_all_tables();
 }

--- a/src/tabs/controller/profiles_controller.cc
+++ b/src/tabs/controller/profiles_controller.cc
@@ -9,6 +9,7 @@
 #include <glibmm.h>
 #include <gtkmm/treeiter.h>
 #include <gtkmm/treepath.h>
+#include <iostream>
 #include <json/json.h>
 #include <memory>
 #include <string>
@@ -57,6 +58,42 @@ void ProfilesController<ProfilesTab, Database, Adapter>::handle_profile_selected
   }
 }
 
+template<class ProfilesTab, class Database, class Adapter>
+void ProfilesController<ProfilesTab, Database, Adapter>::change_status(const std::string &path)
+{
+  auto iter = adapter.get_col_record()->get_iter(path);
+
+  if (iter != nullptr) {
+    auto row = *iter;
+
+    ProfileTableEntry entry;
+    std::string profile;
+    std::string new_status;
+
+    row->get_value(0, entry);
+    row->get_value(1, profile);
+    row->get_value(2, new_status);
+
+    std::string old_status = entry.status;
+
+    // Convert the status strings to lower case.
+    transform(old_status.begin(), old_status.end(), old_status.begin(), ::tolower);
+    transform(new_status.begin(), new_status.end(), new_status.begin(), ::tolower);
+
+    std::string profile_path = prof->find_path(profile);
+
+    this->profile_status_change_fun(profile_path, old_status, new_status);
+  } else {
+    std::cerr << "Error: Could not retrieve row when changing status" << std::endl;
+  }
+}
+
+template<class ProfilesTab, class Database, class Adapter>
+void ProfilesController<ProfilesTab, Database, Adapter>::set_status_change_signal_handler(sigc::slot<void(std::string, std::string, std::string)> change_fun)
+{
+  profile_status_change_fun = std::move(change_fun);
+}
+
 // add_data_to_record() is based on assumptions about the output of aa-status.
 // If those assumptions are incorrect, or aa-status changes, this could crash.
 template<class ProfilesTab, class Database, class Adapter>
@@ -77,8 +114,10 @@ void ProfilesController<ProfilesTab, Database, Adapter>::add_data_to_record(cons
 template<class ProfilesTab, class Database, class Adapter>
 void ProfilesController<ProfilesTab, Database, Adapter>::refresh()
 {
-  uint num_visible = adapter.get_col_record()->filter_rows();
-  prof->set_status_label_text(" " + std::to_string(num_visible) + " matching profiles");
+  std::stringstream label;
+  label << " " << adapter.get_col_record()->filter_rows() << " matching profiles";
+
+  prof->set_status_label_text(label.str());
   handle_profile_selected();
 }
 
@@ -93,6 +132,10 @@ ProfilesController<ProfilesTab, Database, Adapter>::ProfilesController(std::shar
 
   auto filter_fun = sigc::mem_fun(*this, &ProfilesController::filter);
   adapter.get_col_record()->set_visible_func(filter_fun);
+
+  // When the profile status dropdown is changed, attempt to change the status
+  auto change_fun = sigc::mem_fun(*this, &ProfilesController::change_status);
+  adapter.get_col_record()->set_change_func(change_fun);
 
   // When a key/button is pressed or released, check if the selection has changed
   auto button_event_fun = sigc::mem_fun(*this, &ProfilesController::on_button_event);

--- a/src/tabs/controller/profiles_controller.cc
+++ b/src/tabs/controller/profiles_controller.cc
@@ -83,12 +83,6 @@ void ProfilesController<ProfilesTab, Database, Adapter>::refresh()
 }
 
 template<class ProfilesTab, class Database, class Adapter>
-void ProfilesController<ProfilesTab, Database, Adapter>::set_apply_label_text(const std::string &str)
-{
-  prof->set_apply_label_text(str);
-}
-
-template<class ProfilesTab, class Database, class Adapter>
 ProfilesController<ProfilesTab, Database, Adapter>::ProfilesController(std::shared_ptr<Database> database)
   : StatusController<ProfilesTab>(),
     prof{ StatusController<ProfilesTab>::get_tab() },

--- a/src/tabs/controller/profiles_controller.h
+++ b/src/tabs/controller/profiles_controller.h
@@ -17,12 +17,6 @@ public:
   virtual void add_data_to_record(const std::string &data);
   void refresh();
 
-  /**
-   * @brief Change the text in the label next to the Apply button/spinner.
-   * Called by DispatcherMiddleman
-   */
-  void set_apply_label_text(const std::string &str);
-
 protected:
   bool on_button_event(GdkEventButton *event);
   bool on_key_event(GdkEventKey *event);

--- a/src/tabs/controller/profiles_controller.h
+++ b/src/tabs/controller/profiles_controller.h
@@ -14,6 +14,13 @@ class ProfilesController : public StatusController<ProfilesTab>
 public:
   explicit ProfilesController(std::shared_ptr<Database> database);
 
+  // Signal handler to handle when the user wants to change the status of a profile
+  // This calls the default_change_fun with the correct values for the profile, old_status, and new_status
+  void change_status(const std::string &path);
+
+  // Sets the function to be used when changing the status of a profile, this is used in main_window.cc
+  void set_status_change_signal_handler(sigc::slot<void(std::string, std::string, std::string)> change_fun);
+
   virtual void add_data_to_record(const std::string &data);
   void refresh();
 
@@ -25,6 +32,7 @@ protected:
 private:
   std::shared_ptr<ProfilesTab> prof;
   Adapter adapter;
+  sigc::slot<void(std::string, std::string, std::string)> profile_status_change_fun;
 };
 
 #endif // TABS_CONTROLLER_PROFILES_CONTROLLER_H

--- a/src/tabs/model/profile_adapter.cc
+++ b/src/tabs/model/profile_adapter.cc
@@ -67,12 +67,17 @@ uint ProfileAdapter<Database>::get_number_logs(const std::string &profile)
 }
 
 template<class Database>
-ProfileAdapter<Database>::ProfileAdapter(std::shared_ptr<Database> db, const std::shared_ptr<Gtk::TreeView> &view)
+void ProfileAdapter<Database>::set_profile_status_change_func(const StatusColumnRecord::change_function_type &fun)
+{
+  col_record->set_change_func(fun);
+}
+
+template<class Database>
+ProfileAdapter<Database>::ProfileAdapter(std::shared_ptr<Database> db,
+                                         const std::shared_ptr<Gtk::TreeView> &view)
   : db{ db },
     col_record{ StatusColumnRecord::create(view, col_names) }
 {
-  // auto change_fun = sigc::mem_fun(*this, &ProfileAdapter<Database>::handle_profile_status_changed);
-  // col_record->set_change_func(change_fun);
 }
 
 template class ProfileAdapter<Database>;

--- a/src/tabs/model/profile_adapter.cc
+++ b/src/tabs/model/profile_adapter.cc
@@ -71,6 +71,8 @@ ProfileAdapter<Database>::ProfileAdapter(std::shared_ptr<Database> db, const std
   : db{ db },
     col_record{ StatusColumnRecord::create(view, col_names) }
 {
+  // auto change_fun = sigc::mem_fun(*this, &ProfileAdapter<Database>::handle_profile_status_changed);
+  // col_record->set_change_func(change_fun);
 }
 
 template class ProfileAdapter<Database>;

--- a/src/tabs/model/profile_adapter.h
+++ b/src/tabs/model/profile_adapter.h
@@ -35,7 +35,18 @@ private:
 
   const std::vector<ColumnHeader> col_names{ ColumnHeader("Metadata", ColumnHeader::ColumnType::PROFILE_ENTRY),
                                              ColumnHeader("Profile"),
-                                             ColumnHeader("Status") };
+                                             ColumnHeader("Status", {
+                                              {"enforce", "Similar to a whitelist, will only allow actions that are granted by the profile."},
+                                              {"complain", "Similar to a blacklist, will grant any permission that is not explicitly denied by a profile."},
+                                              {"kill", "Equivalent to enforce mode, but kills any process that violates this profile"},
+                                              {"disabled", "This profile exists, but will not actually function to confine processes."},
+
+                                              //// Advanced (Should put in a seperate menu or something)
+                                              // {"Audit", "Ensures all allowed or denied actions are logged"},
+                                              // {"Mediate Deleted", ""},
+                                              // {"Attach Disconnected", ""},
+                                              // {"Chroot Relative", ""},
+                                             }) };
 
   std::shared_ptr<StatusColumnRecord> col_record;
 };

--- a/src/tabs/model/profile_adapter.h
+++ b/src/tabs/model/profile_adapter.h
@@ -18,6 +18,9 @@ public:
   ProfileAdapter(std::shared_ptr<Database> db, const std::shared_ptr<Gtk::TreeView> &view);
 
   void put_data(const std::string &profile_name, const std::string &status);
+
+  void set_profile_status_change_func(const StatusColumnRecord::change_function_type &fun);
+
   std::pair<ProfileTableEntry, bool> get_data(const std::string &profile_name);
 
   std::shared_ptr<StatusColumnRecord> get_col_record();

--- a/src/tabs/model/profile_adapter.h
+++ b/src/tabs/model/profile_adapter.h
@@ -41,11 +41,11 @@ private:
                                              ColumnHeader("Status", {
                                               {"enforce", "Similar to a whitelist, will only allow actions that are granted by the profile."},
                                               {"complain", "Similar to a blacklist, will grant any permission that is not explicitly denied by a profile."},
-                                              {"kill", "Equivalent to enforce mode, but kills any process that violates this profile"},
+                                              {"audit", "Equivalent to enforce mode, but all allowed or denied actions are logged"},
                                               {"disabled", "This profile exists, but will not actually function to confine processes."},
 
                                               //// Advanced (Should put in a seperate menu or something)
-                                              // {"Audit", "Ensures all allowed or denied actions are logged"},
+                                              // {"kill", "Equivalent to enforce mode, but kills any process that violates this profile"},
                                               // {"Mediate Deleted", ""},
                                               // {"Attach Disconnected", ""},
                                               // {"Chroot Relative", ""},

--- a/src/tabs/model/profile_adapter.h
+++ b/src/tabs/model/profile_adapter.h
@@ -36,20 +36,26 @@ public:
 private:
   std::shared_ptr<Database> db;
 
-  const std::vector<ColumnHeader> col_names{ ColumnHeader("Metadata", ColumnHeader::ColumnType::PROFILE_ENTRY),
-                                             ColumnHeader("Profile"),
-                                             ColumnHeader("Status", {
-                                              {"enforce", "Similar to a whitelist, will only allow actions that are granted by the profile."},
-                                              {"complain", "Similar to a blacklist, will grant any permission that is not explicitly denied by a profile."},
-                                              {"audit", "Equivalent to enforce mode, but all allowed or denied actions are logged"},
-                                              {"disabled", "This profile exists, but will not actually function to confine processes."},
+  // clang-format off
+  const std::vector<ColumnHeader> col_names{ 
+    ColumnHeader("Metadata", ColumnHeader::ColumnType::PROFILE_ENTRY),
+    ColumnHeader("Profile"),
+    ColumnHeader("Status",
+      {
+        {"enforce", "Similar to a whitelist, will only allow actions that are granted by the profile."},
+        {"complain", "Similar to a blacklist, will grant any permission that is not explicitly denied by a profile."},
+        {"audit", "Equivalent to enforce mode, but all allowed or denied actions are logged"},
+        {"disabled", "This profile exists, but will not actually function to confine processes."},
 
-                                              //// Advanced (Should put in a seperate menu or something)
-                                              // {"kill", "Equivalent to enforce mode, but kills any process that violates this profile"},
-                                              // {"Mediate Deleted", ""},
-                                              // {"Attach Disconnected", ""},
-                                              // {"Chroot Relative", ""},
-                                             }) };
+        //// Advanced (Should put in a seperate menu or something)
+        // {"kill", "Equivalent to enforce mode, but kills any process that violates this profile"},
+        // {"Mediate Deleted", ""},
+        // {"Attach Disconnected", ""},
+        // {"Chroot Relative", ""},
+      }
+    )
+  };
+  // clang-format on
 
   std::shared_ptr<StatusColumnRecord> col_record;
 };

--- a/src/tabs/model/status_column_record.h
+++ b/src/tabs/model/status_column_record.h
@@ -48,15 +48,26 @@ public:
   void set_visible_func(const Gtk::TreeModelFilter::SlotVisible &filter);
 
   /**
+   * @brief Callback function which for when a user toggles a button, or changes a combobox.
+   *
+   * @details
+   * This callback function takes a string as an argument, which corresponds to the Gtk::Path of the row affected
+   *
+   * @param path the path pointing to the affected row in the Gtk::TreeView
+   */
+  typedef sigc::slot<void, const std::string &> change_function_type;
+
+  /**
    * @brief Sets the callback function which is called whenever a row is edited by the user
    *
    * @details
    * Sets the callback function which is called whenever a row is edited by the user.
-   * This function is called whevener a user toggles a button, or changes a ComboBox.
+   * This function is called whevener a user toggles a button, or edited a ComboBox.
+   * Specifically, this function connects to the signal_edited() function in Gtk::CellRendererCombo
+   * and the signal_toggled() function in Gtk::CellRendererToggle.
    *
-   * @param fun, the callback function to use
+   * @param fun the callback function to use
    */
-  typedef sigc::slot<void, const std::string &> change_function_type;
   void set_change_func(const change_function_type &fun);
 
   /**

--- a/src/tabs/view/profiles.cc
+++ b/src/tabs/view/profiles.cc
@@ -1,8 +1,8 @@
 #include "profiles.h"
 #include "../../threads/command_caller.h"
+#include "../entries.h"
 #include "../model/status_column_record.h"
 #include "common.h"
-
 #include "profile_loader.h"
 #include "profile_modify.h"
 #include "status.h"
@@ -15,40 +15,20 @@
 #include <tuple>
 #include <vector>
 
-void Profiles::change_status()
-{
-  // auto selection = Status::get_view()->get_selection();
-
-  // if (selection->count_selected_rows() == 1) {
-  //   auto row = *selection->get_selected();
-
-  //   std::string profile_path;
-  //   std::string old_status;
-  //   // Get the status that we intend to switch to
-  //   std::string new_status = p_status_selection->get_active_text();
-
-  //   row->get_value(1, profile_path);
-  //   row->get_value(2, old_status);
-
-  //   // Convert the status strings to lower case.
-  //   transform(old_status.begin(), old_status.end(), old_status.begin(), ::tolower);
-  //   transform(new_status.begin(), new_status.end(), new_status.begin(), ::tolower);
-
-  //   this->profile_status_change_fun(profile_path, old_status, new_status);
-  // } else {
-  //   p_apply_info_text->set_text("Please select a row.");
-  // }
-}
-
-void Profiles::set_status_change_signal_handler(sigc::slot<void(std::string, std::string, std::string)> change_fun)
-{
-  profile_status_change_fun = std::move(change_fun);
-}
-
 void Profiles::set_profile_info(const std::string &num_logs, const std::string &num_procs)
 {
   p_num_log_label->set_text(num_logs);
   p_num_proc_label->set_text(num_procs);
+}
+
+std::string Profiles::find_path(const std::string &profile_name)
+{
+  auto pair = profile_map.find(profile_name);
+  if (pair != profile_map.end()) {
+    return pair->second.first.getPath();
+  }
+
+  return "";
 }
 
 void Profiles::show_profile_info()

--- a/src/tabs/view/profiles.cc
+++ b/src/tabs/view/profiles.cc
@@ -17,37 +17,32 @@
 
 void Profiles::change_status()
 {
-  auto selection = Status::get_view()->get_selection();
+  // auto selection = Status::get_view()->get_selection();
 
-  if (selection->count_selected_rows() == 1) {
-    auto row = *selection->get_selected();
+  // if (selection->count_selected_rows() == 1) {
+  //   auto row = *selection->get_selected();
 
-    std::string profile_path;
-    std::string old_status;
-    // Get the status that we intend to switch to
-    std::string new_status = p_status_selection->get_active_text();
+  //   std::string profile_path;
+  //   std::string old_status;
+  //   // Get the status that we intend to switch to
+  //   std::string new_status = p_status_selection->get_active_text();
 
-    row->get_value(1, profile_path);
-    row->get_value(2, old_status);
+  //   row->get_value(1, profile_path);
+  //   row->get_value(2, old_status);
 
-    // Convert the status strings to lower case.
-    transform(old_status.begin(), old_status.end(), old_status.begin(), ::tolower);
-    transform(new_status.begin(), new_status.end(), new_status.begin(), ::tolower);
+  //   // Convert the status strings to lower case.
+  //   transform(old_status.begin(), old_status.end(), old_status.begin(), ::tolower);
+  //   transform(new_status.begin(), new_status.end(), new_status.begin(), ::tolower);
 
-    this->profile_status_change_fun(profile_path, old_status, new_status);
-  } else {
-    p_apply_info_text->set_text("Please select a row.");
-  }
+  //   this->profile_status_change_fun(profile_path, old_status, new_status);
+  // } else {
+  //   p_apply_info_text->set_text("Please select a row.");
+  // }
 }
 
 void Profiles::set_status_change_signal_handler(sigc::slot<void(std::string, std::string, std::string)> change_fun)
 {
   profile_status_change_fun = std::move(change_fun);
-}
-
-void Profiles::set_apply_label_text(const std::string &str)
-{
-  p_apply_info_text->set_text(str);
 }
 
 void Profiles::set_profile_info(const std::string &num_logs, const std::string &num_procs)
@@ -63,9 +58,6 @@ void Profiles::show_profile_info()
   // See if their is a profile selected
   auto selection = Status::get_view()->get_selection();
   if (selection->count_selected_rows() == 1) {
-    // Allow the user to change the state of the profile
-    p_change_state_toggle->set_sensitive(true);
-
     // Get the profile from the selected row
     std::string profile_name;
     auto row = *selection->get_selected();
@@ -83,28 +75,9 @@ void Profiles::show_profile_info()
 void Profiles::hide_profile_info()
 {
   p_profile_info->hide();
-  p_state_selection_box->hide();
-
-  p_change_state_toggle->set_active(false);
-  p_change_state_toggle->set_sensitive(false);
 
   p_modify_profile_toggle->set_active(false);
   p_modify_profile_toggle->set_sensitive(false);
-}
-
-void Profiles::handle_change_state_toggle()
-{
-  bool active = p_change_state_toggle->get_active();
-
-  if (active) {
-    // We cannot have two toggles active at the same time, and the current version of GTKmm does not seem to have button groups
-    p_load_profile_toggle->set_active(false);
-    p_modify_profile_toggle->set_active(false);
-    p_state_selection_box->show_all();
-  } else {
-    // Hide the state selection, when not in use
-    p_state_selection_box->hide();
-  }
 }
 
 void Profiles::handle_load_profile_toggle()
@@ -113,7 +86,6 @@ void Profiles::handle_load_profile_toggle()
 
   if (active) {
     // We cannot have two toggles active at the same time, and the current version of GTKmm does not seem to have button groups
-    p_change_state_toggle->set_active(false);
     p_modify_profile_toggle->set_active(false);
     p_stack->set_visible_child("loadProfile");
   } else {
@@ -127,7 +99,6 @@ void Profiles::handle_modify_profile_toggle()
 
   if (active) {
     // We cannot have two toggles active at the same time, and the current version of GTKmm does not seem to have button groups
-    p_change_state_toggle->set_active(false);
     p_load_profile_toggle->set_active(false);
 
     auto selection = Status::get_view()->get_selection();
@@ -163,14 +134,9 @@ void Profiles::handle_modify_profile_toggle()
 Profiles::Profiles()
   : Status("/resources/profile.glade"),
     builder{ Status::get_builder() },
-    p_change_state_toggle{ Common::get_widget<Gtk::ToggleButton>("p_change_state_toggle", builder) },
     p_load_profile_toggle{ Common::get_widget<Gtk::ToggleButton>("p_load_profile_toggle", builder) },
     p_modify_profile_toggle{ Common::get_widget<Gtk::ToggleButton>("p_modify_profile_toggle", builder) },
     p_stack{ Common::get_widget<Gtk::Stack>("p_stack", builder) },
-    p_state_selection_box{ Common::get_widget<Gtk::Box>("p_state_selection_box", builder) },
-    p_status_selection{ Common::get_widget<Gtk::ComboBoxText>("p_status_selection", builder) },
-    p_apply_button{ Common::get_widget<Gtk::Button>("p_apply_button", builder) },
-    p_apply_info_text{ Common::get_widget<Gtk::Label>("p_apply_info_text", builder) },
     p_profile_info{ Common::get_widget<Gtk::Box>("p_profile_info", builder) },
     p_num_log_label{ Common::get_widget<Gtk::Label>("p_num_log_label", builder) },
     p_num_proc_label{ Common::get_widget<Gtk::Label>("p_num_proc_label", builder) },
@@ -180,10 +146,6 @@ Profiles::Profiles()
   // Add tabs to the stack pane
   p_stack->add(*loader, "loadProfile");
 
-  // Configure the button used for changing a profiles confinement
-  auto change_state_toggle_fun = sigc::mem_fun(*this, &Profiles::handle_change_state_toggle);
-  p_change_state_toggle->signal_toggled().connect(change_state_toggle_fun);
-
   // Configure the button used for loading a profile
   auto load_profile_toggle_fun = sigc::mem_fun(*this, &Profiles::handle_load_profile_toggle);
   p_load_profile_toggle->signal_toggled().connect(load_profile_toggle_fun);
@@ -192,12 +154,7 @@ Profiles::Profiles()
   auto modify_profile_toggle_fun = sigc::mem_fun(*this, &Profiles::handle_modify_profile_toggle);
   p_modify_profile_toggle->signal_toggled().connect(modify_profile_toggle_fun);
 
-  // Set the function to be called when the apply button is pressed
-  auto change_fun = sigc::mem_fun(*this, &Profiles::change_status);
-  p_apply_button->signal_clicked().connect(change_fun);
-
   this->show_all();
 
   this->hide_profile_info();
-  p_state_selection_box->hide();
 }

--- a/src/tabs/view/profiles.h
+++ b/src/tabs/view/profiles.h
@@ -22,19 +22,15 @@ class Profiles : public Status
 public:
   explicit Profiles();
 
-  // Sets the function to be used when changing the status of a profile, this is used in main_window.cc
-  void set_status_change_signal_handler(sigc::slot<void(std::string, std::string, std::string)> change_fun);
-
   void set_profile_info(const std::string &num_logs, const std::string &num_procs);
+
+  // Given a profile name, return the filepath of the profile (if it was found)
+  std::string find_path(const std::string &profile_name);
 
   void show_profile_info();
   void hide_profile_info();
 
 protected:
-  // Signal handler to handle when the user wants to change the status of a profile
-  // This calls the default_change_fun with the correct values for the profile, old_status, and new_status
-  void change_status();
-
   void handle_load_profile_toggle();
   void handle_change_state_toggle();
   void handle_modify_profile_toggle();

--- a/src/tabs/view/profiles.h
+++ b/src/tabs/view/profiles.h
@@ -25,11 +25,6 @@ public:
   // Sets the function to be used when changing the status of a profile, this is used in main_window.cc
   void set_status_change_signal_handler(sigc::slot<void(std::string, std::string, std::string)> change_fun);
 
-  /**
-   * @brief Change the text in the label next to the Apply button/spinner.
-   */
-  void set_apply_label_text(const std::string &str);
-
   void set_profile_info(const std::string &num_logs, const std::string &num_procs);
 
   void show_profile_info();
@@ -50,15 +45,10 @@ private:
   // Widgets
   Glib::RefPtr<Gtk::Builder> builder;
 
-  std::unique_ptr<Gtk::ToggleButton> p_change_state_toggle;
   std::unique_ptr<Gtk::ToggleButton> p_load_profile_toggle;
   std::unique_ptr<Gtk::ToggleButton> p_modify_profile_toggle;
 
   std::unique_ptr<Gtk::Stack> p_stack;
-  std::unique_ptr<Gtk::Box> p_state_selection_box;
-  std::unique_ptr<Gtk::ComboBoxText> p_status_selection;
-  std::unique_ptr<Gtk::Button> p_apply_button;
-  std::unique_ptr<Gtk::Label> p_apply_info_text;
 
   std::unique_ptr<Gtk::Box> p_profile_info;
   std::unique_ptr<Gtk::Label> p_num_log_label;

--- a/src/threads/command_caller.cc
+++ b/src/threads/command_caller.cc
@@ -114,11 +114,8 @@ std::string CommandCaller::execute_change(CommandCaller *caller,
     return "Error: Illegal arguments passed to CommandCaller::execute_change.";
   }
 
-  // Attempt to locate the profile in possible locations
-  std::string profile_location = locate_profile(profile);
-
   // command to change the profile to the provided status
-  std::vector<std::string> command = { "pkexec", status_command, "-d", profile_location, profile };
+  std::vector<std::string> command = { "pkexec", status_command, profile };
   auto result                      = caller->call_command(command);
 
   if (result.exit_status != 0) {

--- a/src/threads/dispatcher_middleman.cc
+++ b/src/threads/dispatcher_middleman.cc
@@ -10,6 +10,7 @@
 #include "../tabs/view/profiles.h"
 
 #include <glibmm/priorities.h>
+#include <iostream>
 #include <mutex>
 #include <sigc++/functors/mem_fun.h>
 
@@ -93,6 +94,7 @@ void DispatcherMiddleman<Profiles, Processes, Logs, Dispatcher, Mutex>::handle_s
       break;
 
     case PROFILES_TEXT:
+      std::cerr << data.string << std::endl;
       break;
 
     case NONE:

--- a/src/threads/dispatcher_middleman.cc
+++ b/src/threads/dispatcher_middleman.cc
@@ -93,7 +93,6 @@ void DispatcherMiddleman<Profiles, Processes, Logs, Dispatcher, Mutex>::handle_s
       break;
 
     case PROFILES_TEXT:
-      prof->set_apply_label_text(data.string);
       break;
 
     case NONE:


### PR DESCRIPTION
This PR modifies how users will change the status of a profile.

Instead of clicking a button in the right pane of the Profile tab, users can modify the status of a Profile by directly interacting with the row. Clicking on a row's "Status" cell will open a Combobox where users can select which status they want to change the Profile to.