### PR TITLE
Fix build for Arch

### DIFF
--- a/src/tabs/column_header.h
+++ b/src/tabs/column_header.h
@@ -41,7 +41,7 @@ struct ColumnHeader
     : type{ COMBO_BOX },
       name{ _name },
       placeholder{ _placeholder },
-      combobox_options{ _combobox_options }
+      combobox_options(_combobox_options)
   {
   }
 };

--- a/src/tabs/column_header.h
+++ b/src/tabs/column_header.h
@@ -37,7 +37,9 @@ struct ColumnHeader
   {
   }
 
-  explicit ColumnHeader(std::string _name, std::string _placeholder, std::initializer_list<std::pair<std::string, std::string>> _combobox_options)
+  explicit ColumnHeader(std::string _name,
+                        std::string _placeholder,
+                        std::initializer_list<std::pair<std::string, std::string>> _combobox_options)
     : type{ COMBO_BOX },
       name{ _name },
       placeholder{ _placeholder },

--- a/src/tabs/controller/processes_controller.cc
+++ b/src/tabs/controller/processes_controller.cc
@@ -18,7 +18,7 @@ unsigned long int safe_convert_pid(const std::string &str)
 {
   try {
     return stoul(str);
-  } catch(std::exception &ex) {
+  } catch (std::exception &ex) {
     std::cerr << ex.what() << std::endl;
     return -1;
   }
@@ -32,9 +32,9 @@ void ProcessesController<ProcessesTab, Database, Adapter>::add_row_from_line(con
 
   unsigned long int pid  = safe_convert_pid(match[1]); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
   unsigned long int ppid = safe_convert_pid(match[2]); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-  std::string user    = match[3];        // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-  std::string status  = match[4];        // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-  std::string process = match[5];        // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+  std::string user       = match[3];                   // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+  std::string status     = match[4];                   // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
+  std::string process    = match[5];                   // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
   // Attempt to get the profile that confines this process (if availible)
   std::string profile;

--- a/src/tabs/controller/profile_modify_controller.cc
+++ b/src/tabs/controller/profile_modify_controller.cc
@@ -39,7 +39,7 @@ void ProfileModifyController::intialize_file_rules()
     auto shared_rule           = std::make_shared<AppArmor::Tree::FileRule>(rule);
     const std::string filename = rule.getFilename();
     const auto filemode        = rule.getFilemode();
-    const auto prefix = rule.getPrefix();
+    const auto prefix          = rule.getPrefix();
 
     auto row = file_rule_record->new_row();
     row->set_value(FILE_RULE_POS::Data, shared_rule);
@@ -114,7 +114,7 @@ void ProfileModifyController::handle_file_rule_changed(const std::string &path)
         AppArmor::Tree::FileRule new_rule(0, -1, rule->getFilename(), new_filemode, rule->getExecTarget(), rule->getIsSubset());
         handle_edit_rule(*rule, new_rule);
       }
-    } catch(const std::exception &ex) {
+    } catch (const std::exception &ex) {
       std::cerr << "Error when specifying Execute Mode:" << std::endl << ex.what() << std::endl;
 
       // Reset the exec_mode to its previous value

--- a/src/tabs/controller/profile_modify_controller.h
+++ b/src/tabs/controller/profile_modify_controller.h
@@ -40,25 +40,25 @@ private:
     ColumnHeader("Execute",
                  "",
                  {
-                                  { "ix", "Inherit execute" },
-                                  { "Px", "Discrete Profile execute" },
-                                  { "Cx", "Transition to Subprofile execute" },
-                                  { "Ux", "Unconfined execute" },
-                                  }
+                   { "ix", "Inherit execute" },
+                   { "Px", "Discrete Profile execute" },
+                   { "Cx", "Transition to Subprofile execute" },
+                   { "Ux", "Unconfined execute" },
+                   }
                  ),
     ColumnHeader("Advanced", ColumnHeader::ColumnType::STRING),
   };
 
   enum FILE_RULE_POS
   {
-    Data      = 0,
-    Path      = 1,
-    Read      = 2,
-    Write     = 3,
-    Link      = 4,
-    Lock      = 5,
-    Exec      = 6,
-    Advanced  = 7,
+    Data     = 0,
+    Path     = 1,
+    Read     = 2,
+    Write    = 3,
+    Link     = 4,
+    Lock     = 5,
+    Exec     = 6,
+    Advanced = 7,
   };
 
   std::stringstream profile_stream;

--- a/src/tabs/controller/profiles_controller.cc
+++ b/src/tabs/controller/profiles_controller.cc
@@ -95,7 +95,8 @@ void ProfilesController<ProfilesTab, Database, Adapter>::change_status(const std
 }
 
 template<class ProfilesTab, class Database, class Adapter>
-void ProfilesController<ProfilesTab, Database, Adapter>::set_status_change_signal_handler(sigc::slot<void(std::string, std::string, std::string)> change_fun)
+void ProfilesController<ProfilesTab, Database, Adapter>::set_status_change_signal_handler(
+  sigc::slot<void(std::string, std::string, std::string)> change_fun)
 {
   profile_status_change_fun = std::move(change_fun);
 }

--- a/src/tabs/model/profile_adapter.cc
+++ b/src/tabs/model/profile_adapter.cc
@@ -73,8 +73,7 @@ void ProfileAdapter<Database>::set_profile_status_change_func(const StatusColumn
 }
 
 template<class Database>
-ProfileAdapter<Database>::ProfileAdapter(std::shared_ptr<Database> db,
-                                         const std::shared_ptr<Gtk::TreeView> &view)
+ProfileAdapter<Database>::ProfileAdapter(std::shared_ptr<Database> db, const std::shared_ptr<Gtk::TreeView> &view)
   : db{ db },
     col_record{ StatusColumnRecord::create(view, col_names) }
 {

--- a/src/tabs/view/profile_modify.cc
+++ b/src/tabs/view/profile_modify.cc
@@ -34,8 +34,7 @@ void ProfileModifyImpl<AppArmorParser>::update_profile_text()
 }
 
 template<class AppArmorParser>
-ProfileModifyImpl<AppArmorParser>::ProfileModifyImpl(std::shared_ptr<AppArmorParser> parser, 
-                                                     std::shared_ptr<AppArmor::Profile> profile)
+ProfileModifyImpl<AppArmorParser>::ProfileModifyImpl(std::shared_ptr<AppArmorParser> parser, std::shared_ptr<AppArmor::Profile> profile)
   : builder{ Gtk::Builder::create_from_resource("/resources/profile_modify.glade") },
     m_box{ Common::get_widget<Gtk::Box>("m_box", builder) },
     m_title_1{ Common::get_widget<Gtk::Label>("m_title_1", builder) },
@@ -44,7 +43,7 @@ ProfileModifyImpl<AppArmorParser>::ProfileModifyImpl(std::shared_ptr<AppArmorPar
     m_abstraction_view{ Common::get_widget<Gtk::TreeView>("m_abstraction_view", builder) },
     m_file_rule_view{ Common::get_widget<Gtk::TreeView>("m_file_rule_view", builder) },
     m_profile_text{ Common::get_widget<Gtk::TextView>("m_profile_text", builder) },
-    parser{parser}
+    parser{ parser }
 {
   const auto &profile_name = profile->name();
   m_title_1->set_label(profile_name);

--- a/src/tabs/view/profile_modify.h
+++ b/src/tabs/view/profile_modify.h
@@ -26,8 +26,7 @@ template<class AppArmorParser>
 class ProfileModifyImpl : public Gtk::ScrolledWindow
 {
 public:
-  ProfileModifyImpl(std::shared_ptr<AppArmorParser> parser,
-                    std::shared_ptr<AppArmor::Profile> profile);
+  ProfileModifyImpl(std::shared_ptr<AppArmorParser> parser, std::shared_ptr<AppArmor::Profile> profile);
 
   std::shared_ptr<Gtk::TreeView> get_abstraction_view();
   std::shared_ptr<Gtk::TreeView> get_file_rule_view();


### PR DESCRIPTION
This fixes issue #53.

For some reason, initializing _combobox_options_ with braces led to a compilation error on Arch-based distributions. I think this might have something to do with the version of clang Arch uses, but I am not sure. Regardless, using parenthesis to construct the field fixed the issue.

I also found and fixed another Arch specific error when testing. It seems `ps` can sometimes return an underscore for "context" when a process is unconfined. This was leading to an issue when using regular exceptions to parse its output. I fixed the issue and made the regex parsing more resilient to exceptions.