### PR TITLE
Fix environment variables of processes spawned with call_command

### DIFF
--- a/aa-caller/src/aa-caller.h
+++ b/aa-caller/src/aa-caller.h
@@ -36,7 +36,7 @@ public:
    * @brief Return the output of `ps`
    *
    * @details
-   * Returns the output of `pkexec ps -A --format pid,ppid,user,context,comm` to get a 
+   * Returns the output of `pkexec ps -A --format pid,ppid,user,context,comm` to get a
    * list of processes which may (or may not) ne confined by apparmor.
    *
    * @returns std::string the raw output of aa-unconfined

--- a/src/threads/command_caller.cc
+++ b/src/threads/command_caller.cc
@@ -10,7 +10,7 @@
 CommandCaller::results CommandCaller::call_command(const std::vector<std::string> &command)
 {
   results result;
-  std::vector<std::string> envp = { "/usr/bin/", "/usr/sbin/", "/usr/local/bin" };
+  std::vector<std::string> envp = { "PATH=/usr/bin/:/usr/sbin/:/usr/local/bin" };
   Glib::spawn_sync(
     "/usr/sbin/", command, envp, Glib::SpawnFlags::SPAWN_SEARCH_PATH_FROM_ENVP, {}, &result.output, &result.error, &result.exit_status);
   return result;


### PR DESCRIPTION
Hi, I was trying AppAnvil (compiled from source and installed in /usr/local/bin/) and i noticed this bug: the program would not display any profile or processes, and this error would come up:

> Error calling 'pkexec'. Cannot run program aa-caller: No such file or directory

i.e. pkexec cannot find the aa-caller binary in /usr/local/bin.

The following line in command_caller.cc (CommandCaller::call_command):

> std::vector<std::string> envp = { "/usr/bin/", "/usr/sbin/", "/usr/local/bin" };

doesn't work because the envp parameter of Glib::spawn_sync expects a vector of environment variables (with the syntax variable=value)

This pull request fixes the problem by setting PATH correctly for spawned processes.
