### PR TITLE
Help Popup

### DIFF
--- a/aa-caller/src/aa-caller.cc
+++ b/aa-caller/src/aa-caller.cc
@@ -13,7 +13,7 @@ AppArmorCaller::results AppArmorCaller::call_command(const std::vector<std::stri
   // Search for the directory where the binary is located
   // Note: Normally we would use the flag Glib::SpawnFlags::SPAWN_SEARCH_PATH_FROM_ENVP
   //       to make Glib search for this. However, I was getting an uncatchable Glib::SpawnError
-  //       that would crash aa-caller. There probably is a better solution, but I resorted to 
+  //       that would crash aa-caller. There probably is a better solution, but I resorted to
   //       manually searching for the binary to avoid this issue.
   std::string command_dir = "";
   for (const auto &dir : possible_directories) {

--- a/resources/help.glade
+++ b/resources/help.glade
@@ -11,7 +11,68 @@
   <object class="GtkPopover" id="help_profile">
     <property name="can-focus">False</property>
     <child>
-      <placeholder/>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Terminology</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+              <attribute name="scale" value="1.1000000000000001"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkStackSwitcher">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="width-request">20</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">center</property>
+            <property name="margin-top">10</property>
+            <property name="hexpand">True</property>
+            <property name="label" translatable="yes">&lt;b&gt;Profile:&lt;/b&gt;  AppArmor policy file, lists which resources an application can access.
+
+&lt;b&gt;Status:&lt;/b&gt; Determines the overall behavior of a profle.
+
+&lt;b&gt;Profile Status Types:&lt;/b&gt;
+  • &lt;b&gt;Enforce:&lt;/b&gt; Similar to a whitelist, only grants permissions that are listed in the profile.
+  • &lt;b&gt;Complain:&lt;/b&gt; Similar to a blacklist, will grant any permission that is not explicitly denied by a profile. For use when developing profiles.
+  • &lt;b&gt;Audit:&lt;/b&gt; Equivalent to enforce mode, but all allowed or denied actions are logged.
+  • &lt;b&gt;Unconfined:&lt;/b&gt; Will not confine applications.
+</property>
+            <property name="use-markup">True</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
     </child>
   </object>
   <object class="GtkPopover" id="help_profile_modify">

--- a/resources/help.glade
+++ b/resources/help.glade
@@ -57,7 +57,7 @@
 
 &lt;b&gt;Profile:&lt;/b&gt; AppArmor policy file, lists resources an application can access.
 
-&lt;b&gt;Status:&lt;/b&gt; Determines the overall behavior of a profle.
+&lt;b&gt;Status:&lt;/b&gt; Determines the overall behavior of a profile.
 
 &lt;b&gt;Status Types:&lt;/b&gt;
   • &lt;b&gt;Enforce:&lt;/b&gt; Similar to a whitelist, only grants permissions that are listed in the profile.
@@ -124,7 +124,7 @@
             <property name="hexpand">True</property>
             <property name="label" translatable="yes">&lt;b&gt;Profile:&lt;/b&gt;  AppArmor policy file, lists which resources an application can access.
 
-&lt;b&gt;Status:&lt;/b&gt; Determines the overall behavior of a profle.
+&lt;b&gt;Status:&lt;/b&gt; Determines the overall behavior of a profile.
 
 &lt;b&gt;Status Types:&lt;/b&gt;
   • &lt;b&gt;Enforce:&lt;/b&gt; Similar to a whitelist, only grants permissions that are listed in the profile.

--- a/resources/help.glade
+++ b/resources/help.glade
@@ -8,6 +8,12 @@
       <placeholder/>
     </child>
   </object>
+  <object class="GtkPopover" id="help_process">
+    <property name="can-focus">False</property>
+    <child>
+      <placeholder/>
+    </child>
+  </object>
   <object class="GtkPopover" id="help_profile">
     <property name="can-focus">False</property>
     <child>
@@ -73,12 +79,6 @@
           </packing>
         </child>
       </object>
-    </child>
-  </object>
-  <object class="GtkPopover" id="help_profile_modify">
-    <property name="can-focus">False</property>
-    <child>
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/resources/help.glade
+++ b/resources/help.glade
@@ -5,7 +5,64 @@
   <object class="GtkPopover" id="help_logs">
     <property name="can-focus">False</property>
     <child>
-      <placeholder/>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Terminology</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+              <attribute name="scale" value="1.1000000000000001"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkStackSwitcher">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="width-request">20</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">center</property>
+            <property name="margin-top">10</property>
+            <property name="hexpand">True</property>
+            <property name="label" translatable="yes">&lt;b&gt;Common Log Types:&lt;/b&gt;
+  • &lt;b&gt;STATUS:&lt;/b&gt; Marks a change in AppArmor configuration
+  • &lt;b&gt;DENIED:&lt;/b&gt; Emitted when a process is denied access to a resource, unless a deny rule was triggered
+  • &lt;b&gt;ALLOWED:&lt;/b&gt; Emitted when a process in &lt;i&gt;Complain&lt;/i&gt; mode is granted access to a resource that would be denied in &lt;i&gt;Enforce&lt;/i&gt; mode
+  • &lt;b&gt;AUDIT:&lt;/b&gt; Emitted when any rule with an audit flag is triggered
+</property>
+            <property name="use-markup">True</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
     </child>
   </object>
   <object class="GtkPopover" id="help_process">

--- a/resources/help.glade
+++ b/resources/help.glade
@@ -11,7 +11,70 @@
   <object class="GtkPopover" id="help_process">
     <property name="can-focus">False</property>
     <child>
-      <placeholder/>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="margin-start">10</property>
+        <property name="margin-end">10</property>
+        <property name="margin-top">10</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Terminology</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+              <attribute name="scale" value="1.1000000000000001"/>
+            </attributes>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkStackSwitcher">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="width-request">20</property>
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">center</property>
+            <property name="margin-top">10</property>
+            <property name="hexpand">True</property>
+            <property name="label" translatable="yes">&lt;b&gt;Process:&lt;/b&gt;  Instance of a running program. Processes can be confined by a Profile.
+
+&lt;b&gt;Profile:&lt;/b&gt; AppArmor policy file, lists resources an application can access.
+
+&lt;b&gt;Status:&lt;/b&gt; Determines the overall behavior of a profle.
+
+&lt;b&gt;Status Types:&lt;/b&gt;
+  • &lt;b&gt;Enforce:&lt;/b&gt; Similar to a whitelist, only grants permissions that are listed in the profile.
+  • &lt;b&gt;Complain:&lt;/b&gt; Similar to a blacklist, will grant any permission that is not explicitly denied by a profile. For use when developing profiles.
+  • &lt;b&gt;Audit:&lt;/b&gt; Equivalent to enforce mode, but all allowed or denied actions are logged.
+  • &lt;b&gt;Unconfined:&lt;/b&gt; Will not confine applications.
+</property>
+            <property name="use-markup">True</property>
+            <property name="wrap">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
     </child>
   </object>
   <object class="GtkPopover" id="help_profile">
@@ -63,7 +126,7 @@
 
 &lt;b&gt;Status:&lt;/b&gt; Determines the overall behavior of a profle.
 
-&lt;b&gt;Profile Status Types:&lt;/b&gt;
+&lt;b&gt;Status Types:&lt;/b&gt;
   • &lt;b&gt;Enforce:&lt;/b&gt; Similar to a whitelist, only grants permissions that are listed in the profile.
   • &lt;b&gt;Complain:&lt;/b&gt; Similar to a blacklist, will grant any permission that is not explicitly denied by a profile. For use when developing profiles.
   • &lt;b&gt;Audit:&lt;/b&gt; Equivalent to enforce mode, but all allowed or denied actions are logged.

--- a/resources/help.glade
+++ b/resources/help.glade
@@ -1,118 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkBox" id="h_box">
-    <property name="visible">True</property>
+  <object class="GtkPopover" id="help_logs">
     <property name="can-focus">False</property>
-    <property name="hexpand">True</property>
-    <property name="vexpand">True</property>
-    <property name="orientation">vertical</property>
     <child>
-      <object class="GtkScrolledWindow">
-        <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="hexpand">True</property>
-        <property name="vexpand">True</property>
-        <property name="shadow-type">in</property>
-        <child>
-          <object class="GtkViewport">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">start</property>
-            <property name="valign">start</property>
-            <child>
-              <object class="GtkLabel" id="h_label">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="halign">start</property>
-                <property name="valign">start</property>
-                <property name="margin-start">10</property>
-                <property name="margin-end">10</property>
-                <property name="margin-top">10</property>
-                <property name="margin-bottom">10</property>
-                <property name="hexpand">False</property>
-                <property name="vexpand">False</property>
-                <property name="label" translatable="yes">&lt;span size="110%" weight="bold"&gt;What is AppAnvil?&lt;/span&gt;
-AppAnvil is a graphical user interface (GUI) designed to facilitate the use of AppArmor.
-
-&lt;span size="110%" weight="bold"&gt;What is AppArmor?&lt;/span&gt;
-AppArmor is a Linux security module that protects your system from potential threats by imposing Mandatory Access Control (MAC). It allows the user to secure individual applications by defining and restricting what resources an application can access or share.
-
-&lt;span size="110%" weight="bold"&gt;What is a profile?&lt;/span&gt;
-Profiles are the user-defined restrictions for an application. They determine what resources applications can access or share. 
-
-One use case for a profile is to block access to sensitive files.
-
-&lt;u&gt;Profiles are able to run in:&lt;/u&gt;
-    - Complain mode: the profile does not enforce the rules defined but reports any violations to the logs
-    - Enforce mode: the profile enforces the rules defined
-
-You can change the mode of your profile(s) under the 'Profile' tab.
-
-&lt;span size="110%" weight="bold"&gt;What information do logs contain?&lt;/span&gt;
-Logs contain information for each AppArmor event, which make them useful for debugging.
-
-&lt;u&gt;Logs contain:&lt;/u&gt;
-&lt;i&gt;Time&lt;/i&gt;
-    - Timestamp of event logged
-&lt;i&gt;Type&lt;/i&gt;
-    - DENIED: an access is denied when a profile in enforce mode violates rules
-    - STATUS: an access is allowed, but the access violated rules of a profile in complain mode
-&lt;i&gt;Operation&lt;/i&gt;
-    - Profile load: load an AppArmor profile into the kernel
-    - Profile Replace: replacing current AppArmor profile
-    - Open: attempt to access file
-    - rmdir: remove directory of profile
-&lt;i&gt;Name&lt;/i&gt;
-    - Full path of the executable
-    
-You can access log information under the 'Logs' tab.
-
-&lt;span size="110%" weight="bold"&gt;How do I monitor specific processes?&lt;/span&gt;
-You can monitor processes with existing AppArmor profiles under the 'Processes' tab.</property>
-                <property name="use-markup">True</property>
-                <property name="wrap">True</property>
-                <property name="wrap-mode">word-char</property>
-                <property name="selectable">True</property>
-              </object>
-            </child>
-          </object>
-        </child>
-      </object>
-      <packing>
-        <property name="expand">True</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
+      <placeholder/>
     </child>
+  </object>
+  <object class="GtkPopover" id="help_profile">
+    <property name="can-focus">False</property>
     <child>
-      <object class="GtkBox" id="h_searchbox">
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <child>
-          <object class="GtkSearchEntry" id="h_search">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">10</property>
-            <property name="margin-top">5</property>
-            <property name="primary-icon-name">edit-find-symbolic</property>
-            <property name="primary-icon-activatable">False</property>
-            <property name="primary-icon-sensitive">False</property>
-          </object>
-          <packing>
-            <property name="expand">True</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
+      <placeholder/>
+    </child>
+  </object>
+  <object class="GtkPopover" id="help_profile_modify">
+    <property name="can-focus">False</property>
+    <child>
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/src/main_window.cc
+++ b/src/main_window.cc
@@ -93,10 +93,13 @@ bool MainWindow::on_switch(GdkEvent *event)
   const std::string visible_child = m_tab_stack.get_visible_child_name();
   if (visible_child == "prof") {
     console->send_refresh_message(PROFILE);
+    help_toggle.set_help_type(Help::Type::PROFILE);
   } else if (visible_child == "proc") {
     console->send_refresh_message(PROCESS);
+    help_toggle.set_help_type(Help::Type::PROCESS);
   } else if (visible_child == "logs") {
     console->send_refresh_message(LOGS);
+    help_toggle.set_help_type(Help::Type::LOGS);
   }
 
   return false;

--- a/src/main_window.h
+++ b/src/main_window.h
@@ -79,12 +79,13 @@ private:
   Glib::RefPtr<Gtk::Builder> builder;
 
   // Member widgets:
-  Gtk::Stack m_top_stack;
   Gtk::Stack m_tab_stack;
   Gtk::HeaderBar m_headerbar;
   Gtk::StackSwitcher m_switcher;
-  Gtk::ToggleButton m_help_button;
   Gtk::ToggleButton m_search_button;
+
+  // Custom ToggleButton, which opens popup containers
+  Help help_toggle;
 
   // Data structure for sharing data related to AppArmor between tabs
   std::shared_ptr<Database> database;
@@ -94,14 +95,8 @@ private:
   std::shared_ptr<ProcessesControllerInstance> proc_control;
   std::shared_ptr<LogsControllerInstance> logs_control;
 
-  // Tab (Without Controller)
-  std::shared_ptr<Help> help;
-
   // Second thread for calling command line utilities
   std::shared_ptr<ConsoleThreadInstance> console;
-
-  // Controls whether a the 'Search' button is visible
-  void handle_search_button_visiblity();
 };
 
 #endif // MAIN_WINDOW_H

--- a/src/tabs/model/log_adapter.h
+++ b/src/tabs/model/log_adapter.h
@@ -43,7 +43,7 @@ private:
                                              ColumnHeader("Time"),
                                              ColumnHeader("Type"),
                                              ColumnHeader("Operation"),
-                                             ColumnHeader("Name"),
+                                             ColumnHeader("Profile"),
                                              ColumnHeader("Pid", ColumnHeader::ColumnType::INT) };
 
   const std::shared_ptr<ColumnRecord> col_record;

--- a/src/tabs/view/help.cc
+++ b/src/tabs/view/help.cc
@@ -1,28 +1,34 @@
 #include "common.h"
 #include "help.h"
 
-Help::Help()
+Help::Help(Help::Type help_type)
   : builder{ Gtk::Builder::create_from_resource("/resources/help.glade") },
     help_profile{ Common::get_widget<Gtk::Popover>("help_profile", builder) },
-    help_profile_modify{ Common::get_widget<Gtk::Popover>("help_profile_modify", builder) },
-    help_logs{ Common::get_widget<Gtk::Popover>("help_logs", builder) }
+    help_process{ Common::get_widget<Gtk::Popover>("help_process", builder) },
+    help_logs{ Common::get_widget<Gtk::Popover>("help_logs", builder) },
+    help_type{help_type}
 {
   // Set the image for this button
   this->set_image_from_icon_name("dialog-question");
 
   // Make popups point to this ToggleButton
   help_profile->set_relative_to(*this);
-  help_profile_modify->set_relative_to(*this);
+  help_process->set_relative_to(*this);
   help_logs->set_relative_to(*this);
 
   // Ensure popups are not modal
   // That other inputs on the screen can be pressed when they are displayed
   help_profile->set_modal(false);
-  help_profile_modify->set_modal(false);
+  help_process->set_modal(false);
   help_logs->set_modal(false);
 
   auto help_toggle_fun = sigc::mem_fun(*this, &Help::on_help_toggle);
   this->signal_toggled().connect(help_toggle_fun, true);
+}
+
+void Help::set_help_type(Help::Type help_type)
+{
+  this->help_type = help_type;
 }
 
 void Help::on_help_toggle()
@@ -30,8 +36,23 @@ void Help::on_help_toggle()
   bool active = this->get_active();
 
   if(active) {
-    help_profile->show();
+    switch(help_type)
+    {
+      case Help::Type::PROFILE:
+      help_profile->show();
+      break;
+
+      case Help::Type::PROCESS:
+      help_process->show();
+      break;
+
+      case Help::Type::LOGS:
+      help_logs->show();
+      break;
+    };
   } else {
     help_profile->hide();
+    help_process->hide();
+    help_logs->hide();
   }
 }

--- a/src/tabs/view/help.cc
+++ b/src/tabs/view/help.cc
@@ -1,12 +1,12 @@
-#include "common.h"
 #include "help.h"
+#include "common.h"
 
 Help::Help(Help::Type help_type)
   : builder{ Gtk::Builder::create_from_resource("/resources/help.glade") },
     help_profile{ Common::get_widget<Gtk::Popover>("help_profile", builder) },
     help_process{ Common::get_widget<Gtk::Popover>("help_process", builder) },
     help_logs{ Common::get_widget<Gtk::Popover>("help_logs", builder) },
-    help_type{help_type}
+    help_type{ help_type }
 {
   // Set the image for this button
   this->set_image_from_icon_name("dialog-question");
@@ -42,20 +42,19 @@ void Help::on_help_toggle()
   help_process->hide();
   help_logs->hide();
 
-  if(active) {
-    switch(help_type)
-    {
+  if (active) {
+    switch (help_type) {
       case Help::Type::PROFILE:
-      help_profile->show();
-      break;
+        help_profile->show();
+        break;
 
       case Help::Type::PROCESS:
-      help_process->show();
-      break;
+        help_process->show();
+        break;
 
       case Help::Type::LOGS:
-      help_logs->show();
-      break;
+        help_logs->show();
+        break;
     };
   }
 }

--- a/src/tabs/view/help.cc
+++ b/src/tabs/view/help.cc
@@ -29,11 +29,18 @@ Help::Help(Help::Type help_type)
 void Help::set_help_type(Help::Type help_type)
 {
   this->help_type = help_type;
+
+  // If the help button is toggled, then update the popover
+  on_help_toggle();
 }
 
 void Help::on_help_toggle()
 {
   bool active = this->get_active();
+
+  help_profile->hide();
+  help_process->hide();
+  help_logs->hide();
 
   if(active) {
     switch(help_type)
@@ -50,9 +57,5 @@ void Help::on_help_toggle()
       help_logs->show();
       break;
     };
-  } else {
-    help_profile->hide();
-    help_process->hide();
-    help_logs->hide();
   }
 }

--- a/src/tabs/view/help.h
+++ b/src/tabs/view/help.h
@@ -2,8 +2,8 @@
 #define TABS_VIEW_HELP_H
 
 #include <gtkmm/builder.h>
-#include <gtkmm/togglebutton.h>
 #include <gtkmm/popover.h>
+#include <gtkmm/togglebutton.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -11,7 +11,8 @@
 class Help : public Gtk::ToggleButton
 {
 public:
-  enum Type {
+  enum Type
+  {
     PROFILE,
     PROCESS,
     LOGS

--- a/src/tabs/view/help.h
+++ b/src/tabs/view/help.h
@@ -11,7 +11,15 @@
 class Help : public Gtk::ToggleButton
 {
 public:
-  Help();
+  enum Type {
+    PROFILE,
+    PROCESS,
+    LOGS
+  };
+
+  explicit Help(Help::Type help_type = Help::Type::PROFILE);
+
+  void set_help_type(Help::Type help_type);
 
 protected:
   void on_help_toggle();
@@ -22,8 +30,11 @@ private:
 
   // Widgets on the tab
   std::unique_ptr<Gtk::Popover> help_profile;
-  std::unique_ptr<Gtk::Popover> help_profile_modify;
+  std::unique_ptr<Gtk::Popover> help_process;
   std::unique_ptr<Gtk::Popover> help_logs;
+
+  // Popup that should show up
+  Help::Type help_type;
 };
 
 #endif // TABS_VIEW_HELP_H

--- a/src/tabs/view/help.h
+++ b/src/tabs/view/help.h
@@ -1,52 +1,29 @@
 #ifndef TABS_VIEW_HELP_H
 #define TABS_VIEW_HELP_H
 
-#include "status.h"
-
 #include <gtkmm/builder.h>
-#include <gtkmm/comboboxtext.h>
-#include <gtkmm/enums.h>
-#include <gtkmm/fixed.h>
-#include <gtkmm/grid.h>
-#include <gtkmm/liststore.h>
-#include <gtkmm/notebook.h>
-#include <gtkmm/scrolledwindow.h>
-#include <gtkmm/searchentry.h>
-#include <gtkmm/textview.h>
-#include <gtkmm/treemodelcolumn.h>
-#include <gtkmm/treeview.h>
-#include <gtkmm/treeviewcolumn.h>
-#include <gtkmm/viewport.h>
+#include <gtkmm/togglebutton.h>
+#include <gtkmm/popover.h>
 #include <memory>
 #include <string>
 #include <vector>
 
-class Help : public Gtk::ScrolledWindow
+class Help : public Gtk::ToggleButton
 {
 public:
   Help();
 
-  void hide_searchbar();
-  void show_searchbar(const bool &should_focus);
-
 protected:
-  // Signal handlers
-  void set_search_signal_handler(const Glib::SignalProxyProperty::SlotType &func);
-  void on_search_changed();
+  void on_help_toggle();
 
 private:
   // GUI Builder to parse UI from xml file
   Glib::RefPtr<Gtk::Builder> builder;
 
   // Widgets on the tab
-  std::unique_ptr<Gtk::Box> h_box;
-  std::unique_ptr<Gtk::Label> h_label;
-  std::unique_ptr<Gtk::Box> h_searchbox;
-  std::unique_ptr<Gtk::SearchEntry> h_search;
-
-  // The text that is shown
-  // const std::string description;
-  const std::string description;
+  std::unique_ptr<Gtk::Popover> help_profile;
+  std::unique_ptr<Gtk::Popover> help_profile_modify;
+  std::unique_ptr<Gtk::Popover> help_logs;
 };
 
 #endif // TABS_VIEW_HELP_H


### PR DESCRIPTION
Previously, when users pressed the "Help" button (labeled with a question mark), a page appeared to describe a set of topics related to AppArmor. 

In my opinion, that page was hard to read and not very helpful. In particular, we should limit the amount of information that is thrust onto the user at one time.

I made some changes so that the "Help" button now opens a small popup box, instead of an entire page. The contents of this popup box change depending on what tab AppAnvil is displaying. Currently, the box explains AppArmor terminology that may be unknown or confusing to a novice user.

Eventually, I would like to tailor help information for other pages, like the "Profile Modify" page. I am also considering adding a section to explain the types of actions a user can perform using AppAnvil.
