### PR TITLE
Configurable pkexec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ resources/*.glade~
 resources/#*#
 src/resource.autogen.c
 resources/resource.autogen.c
+resources/com.github.jack-ullery.AppAnvil.pkexec.policy
 
 dist/
 lib/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,9 @@ set(PROJECT_RESOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/resources)
 set(XML_GRESOURCE ${PROJECT_RESOURCE_DIR}/resources.gresource.xml)
 set(RESOURCE_BUNDLE_OUTPUT ${PROJECT_RESOURCE_DIR}/resource.autogen.c)
 
+set(PKEXEC_POLICY_IN ${PROJECT_RESOURCE_DIR}/pkexec.policy.in)
 set(PKEXEC_POLICY ${PROJECT_RESOURCE_DIR}/com.github.jack-ullery.AppAnvil.pkexec.policy)
+configure_file("${PKEXEC_POLICY_IN}" "${PKEXEC_POLICY}" @ONLY) 
 
 #### Add Linters and Static Analysis ####
 

--- a/resources/pkexec.policy.in
+++ b/resources/pkexec.policy.in
@@ -10,8 +10,7 @@
     <defaults>
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/aa-caller</annotate>
-    <annotate key="org.freedesktop.policykit.exec.path">/bin/aa-caller</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">@CMAKE_INSTALL_PREFIX@/bin/aa-caller</annotate>
   </action>
 
 </policyconfig>


### PR DESCRIPTION
Previously, there has been an issue where the pkexec policy would not apply to some builds. The default CMake install prefix is `/usr/local`. However, the pkexec policy would only apply if the build prefix was changed to `/usr`.

I modified the policy file to be configured automatically by CMake, so that the it will always point to the correct aa-caller binary when installed.  