### PR TITLE
Add cancel/apply buttons to ProfileModify 

### DIFF
--- a/resources/profile_modify.glade
+++ b/resources/profile_modify.glade
@@ -320,27 +320,71 @@
             <property name="transition-duration">200</property>
             <property name="reveal-child">True</property>
             <child>
-              <object class="GtkButtonBox">
+              <object class="GtkBox">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="halign">end</property>
-                <property name="margin-start">5</property>
+                <property name="margin-start">10</property>
                 <property name="margin-end">10</property>
                 <property name="margin-top">5</property>
                 <property name="margin-bottom">5</property>
-                <property name="hexpand">True</property>
-                <property name="layout-style">start</property>
+                <property name="spacing">5</property>
                 <child>
-                  <placeholder/>
+                  <object class="GtkButtonBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="hexpand">True</property>
+                    <child>
+                      <object class="GtkButton" id="m_cancel_button">
+                        <property name="label">gtk-cancel</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="use-stock">True</property>
+                        <property name="always-show-image">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="m_apply_button">
+                        <property name="label">gtk-apply</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="use-stock">True</property>
+                        <property name="always-show-image">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <style>
+                      <class name="linked"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack-type">end</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="m_cancel_button">
-                    <property name="label">gtk-cancel</property>
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">True</property>
-                    <property name="use-stock">True</property>
-                    <property name="always-show-image">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">There are unsaved changes </property>
+                    <attributes>
+                      <attribute name="style" value="italic"/>
+                    </attributes>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -348,24 +392,6 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
-                <child>
-                  <object class="GtkButton" id="m_apply_button">
-                    <property name="label">gtk-apply</property>
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">True</property>
-                    <property name="use-stock">True</property>
-                    <property name="always-show-image">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <style>
-                  <class name="linked"/>
-                </style>
               </object>
             </child>
           </object>

--- a/resources/profile_modify.glade
+++ b/resources/profile_modify.glade
@@ -313,57 +313,66 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButtonBox" id="m_button_box">
+          <object class="GtkRevealer" id="m_button_reveal">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="halign">end</property>
-            <property name="margin-start">5</property>
-            <property name="margin-end">10</property>
-            <property name="margin-top">5</property>
-            <property name="margin-bottom">5</property>
-            <property name="hexpand">True</property>
-            <property name="layout-style">start</property>
+            <property name="transition-type">slide-up</property>
+            <property name="transition-duration">200</property>
+            <property name="reveal-child">True</property>
             <child>
-              <placeholder/>
-            </child>
-            <child>
-              <object class="GtkButton" id="m_cancel_button">
-                <property name="label">gtk-cancel</property>
+              <object class="GtkButtonBox">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
-                <property name="always-show-image">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">end</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">10</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="hexpand">True</property>
+                <property name="layout-style">start</property>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <object class="GtkButton" id="m_cancel_button">
+                    <property name="label">gtk-cancel</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="use-stock">True</property>
+                    <property name="always-show-image">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="m_apply_button">
+                    <property name="label">gtk-apply</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="use-stock">True</property>
+                    <property name="always-show-image">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <style>
+                  <class name="linked"/>
+                </style>
               </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
             </child>
-            <child>
-              <object class="GtkButton" id="m_apply_button">
-                <property name="label">gtk-apply</property>
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
-                <property name="always-show-image">True</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">2</property>
-              </packing>
-            </child>
-            <style>
-              <class name="linked"/>
-            </style>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/resources/profile_modify.glade
+++ b/resources/profile_modify.glade
@@ -20,284 +20,350 @@
       </packing>
     </child>
     <child>
-      <object class="GtkStack" id="m_stack">
+      <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can-focus">False</property>
-        <property name="hexpand">True</property>
-        <property name="vexpand">True</property>
+        <property name="orientation">vertical</property>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkStack" id="m_stack">
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
+            <property name="can-focus">False</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
-            <property name="hscrollbar-policy">never</property>
             <child>
-              <object class="GtkViewport">
+              <object class="GtkScrolledWindow">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can-focus">True</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">True</property>
+                <property name="hscrollbar-policy">never</property>
                 <child>
-                  <object class="GtkBox">
+                  <object class="GtkViewport">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="margin-start">10</property>
-                    <property name="margin-end">15</property>
-                    <property name="margin-bottom">5</property>
                     <property name="hexpand">True</property>
-                    <property name="orientation">vertical</property>
+                    <property name="vexpand">True</property>
                     <child>
-                      <object class="GtkLabel" id="m_title_1">
+                      <object class="GtkBox">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="tooltip-text" translatable="yes">The name of this profile</property>
-                        <property name="halign">start</property>
-                        <property name="margin-end">10</property>
-                        <property name="margin-top">10</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">15</property>
                         <property name="margin-bottom">5</property>
-                        <property name="hexpand">False</property>
-                        <property name="label" translatable="yes">Profile Name</property>
-                        <property name="selectable">True</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                          <attribute name="variant" value="title-caps"/>
-                          <attribute name="scale" value="1.3999999999999999"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin-top">10</property>
-                        <property name="margin-bottom">5</property>
-                        <property name="label" translatable="yes">Abstractions</property>
-                        <property name="selectable">True</property>
-                        <attributes>
-                          <attribute name="weight" value="normal"/>
-                          <attribute name="variant" value="title-caps"/>
-                          <attribute name="scale" value="1.2"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkTreeView" id="m_abstraction_view">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="hscroll-policy">natural</property>
-                        <property name="vscroll-policy">natural</property>
-                        <property name="reorderable">True</property>
-                        <property name="enable-grid-lines">both</property>
-                        <child internal-child="selection">
-                          <object class="GtkTreeSelection"/>
+                        <property name="hexpand">True</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkLabel" id="m_title_1">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="tooltip-text" translatable="yes">The name of this profile</property>
+                            <property name="halign">start</property>
+                            <property name="margin-end">10</property>
+                            <property name="margin-top">10</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="hexpand">False</property>
+                            <property name="label" translatable="yes">Profile Name</property>
+                            <property name="selectable">True</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                              <attribute name="variant" value="title-caps"/>
+                              <attribute name="scale" value="1.3999999999999999"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin-top">10</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="label" translatable="yes">Abstractions</property>
+                            <property name="selectable">True</property>
+                            <attributes>
+                              <attribute name="weight" value="normal"/>
+                              <attribute name="variant" value="title-caps"/>
+                              <attribute name="scale" value="1.2"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkTreeView" id="m_abstraction_view">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="hscroll-policy">natural</property>
+                            <property name="vscroll-policy">natural</property>
+                            <property name="reorderable">True</property>
+                            <property name="enable-grid-lines">both</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">3</property>
-                      </packing>
                     </child>
                   </object>
                 </child>
               </object>
+              <packing>
+                <property name="name">abstractions</property>
+                <property name="title" translatable="yes">Abstractions</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="hscrollbar-policy">never</property>
+                <child>
+                  <object class="GtkViewport">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">15</property>
+                        <property name="margin-bottom">5</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkLabel" id="m_title_2">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="tooltip-text" translatable="yes">The name of this profile</property>
+                            <property name="halign">start</property>
+                            <property name="margin-end">10</property>
+                            <property name="margin-top">10</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="hexpand">False</property>
+                            <property name="label" translatable="yes">Profile Name</property>
+                            <property name="selectable">True</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                              <attribute name="variant" value="title-caps"/>
+                              <attribute name="scale" value="1.3999999999999999"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin-top">10</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="label" translatable="yes">File Rules</property>
+                            <property name="selectable">True</property>
+                            <attributes>
+                              <attribute name="weight" value="normal"/>
+                              <attribute name="variant" value="title-caps"/>
+                              <attribute name="scale" value="1.2"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkTreeView" id="m_file_rule_view">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="hscroll-policy">natural</property>
+                            <property name="vscroll-policy">natural</property>
+                            <property name="reorderable">True</property>
+                            <property name="enable-grid-lines">both</property>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection"/>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">3</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="name">file_rule</property>
+                <property name="title" translatable="yes">File Rules</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="hscrollbar-policy">never</property>
+                <child>
+                  <object class="GtkViewport">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">15</property>
+                        <property name="margin-bottom">5</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <object class="GtkLabel" id="m_title_3">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="tooltip-text" translatable="yes">The name of this profile</property>
+                            <property name="halign">start</property>
+                            <property name="margin-end">10</property>
+                            <property name="margin-top">10</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="hexpand">False</property>
+                            <property name="label" translatable="yes">Profile Name</property>
+                            <property name="selectable">True</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                              <attribute name="variant" value="title-caps"/>
+                              <attribute name="scale" value="1.3999999999999999"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="margin-top">10</property>
+                            <property name="margin-bottom">5</property>
+                            <property name="label" translatable="yes">Profile Text</property>
+                            <property name="selectable">True</property>
+                            <attributes>
+                              <attribute name="weight" value="normal"/>
+                              <attribute name="variant" value="title-caps"/>
+                              <attribute name="scale" value="1.2"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkTextView" id="m_profile_text">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="monospace">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="name">raw_profile</property>
+                <property name="title" translatable="yes">Profile Text</property>
+                <property name="position">2</property>
+              </packing>
             </child>
           </object>
           <packing>
-            <property name="name">abstractions</property>
-            <property name="title" translatable="yes">Abstractions</property>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <object class="GtkScrolledWindow">
+          <object class="GtkButtonBox" id="m_button_box">
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">end</property>
+            <property name="margin-start">5</property>
+            <property name="margin-end">10</property>
+            <property name="margin-top">5</property>
+            <property name="margin-bottom">5</property>
             <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
-            <property name="hscrollbar-policy">never</property>
+            <property name="layout-style">start</property>
             <child>
-              <object class="GtkViewport">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="margin-start">10</property>
-                    <property name="margin-end">15</property>
-                    <property name="margin-bottom">5</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkLabel" id="m_title_2">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="tooltip-text" translatable="yes">The name of this profile</property>
-                        <property name="halign">start</property>
-                        <property name="margin-end">10</property>
-                        <property name="margin-top">10</property>
-                        <property name="margin-bottom">5</property>
-                        <property name="hexpand">False</property>
-                        <property name="label" translatable="yes">Profile Name</property>
-                        <property name="selectable">True</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                          <attribute name="variant" value="title-caps"/>
-                          <attribute name="scale" value="1.3999999999999999"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin-top">10</property>
-                        <property name="margin-bottom">5</property>
-                        <property name="label" translatable="yes">File Rules</property>
-                        <property name="selectable">True</property>
-                        <attributes>
-                          <attribute name="weight" value="normal"/>
-                          <attribute name="variant" value="title-caps"/>
-                          <attribute name="scale" value="1.2"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkTreeView" id="m_file_rule_view">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="hscroll-policy">natural</property>
-                        <property name="vscroll-policy">natural</property>
-                        <property name="reorderable">True</property>
-                        <property name="enable-grid-lines">both</property>
-                        <child internal-child="selection">
-                          <object class="GtkTreeSelection"/>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">3</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
+              <placeholder/>
             </child>
+            <child>
+              <object class="GtkButton" id="m_cancel_button">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
+                <property name="always-show-image">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="m_apply_button">
+                <property name="label">gtk-apply</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
+                <property name="always-show-image">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <style>
+              <class name="linked"/>
+            </style>
           </object>
           <packing>
-            <property name="name">file_rule</property>
-            <property name="title" translatable="yes">File Rules</property>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
             <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkScrolledWindow">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
-            <property name="hscrollbar-policy">never</property>
-            <child>
-              <object class="GtkViewport">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <child>
-                  <object class="GtkBox">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="margin-start">10</property>
-                    <property name="margin-end">15</property>
-                    <property name="margin-bottom">5</property>
-                    <property name="orientation">vertical</property>
-                    <child>
-                      <object class="GtkLabel" id="m_title_3">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="tooltip-text" translatable="yes">The name of this profile</property>
-                        <property name="halign">start</property>
-                        <property name="margin-end">10</property>
-                        <property name="margin-top">10</property>
-                        <property name="margin-bottom">5</property>
-                        <property name="hexpand">False</property>
-                        <property name="label" translatable="yes">Profile Name</property>
-                        <property name="selectable">True</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                          <attribute name="variant" value="title-caps"/>
-                          <attribute name="scale" value="1.3999999999999999"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="margin-top">10</property>
-                        <property name="margin-bottom">5</property>
-                        <property name="label" translatable="yes">Profile Text</property>
-                        <property name="selectable">True</property>
-                        <attributes>
-                          <attribute name="weight" value="normal"/>
-                          <attribute name="variant" value="title-caps"/>
-                          <attribute name="scale" value="1.2"/>
-                        </attributes>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkTextView" id="m_profile_text">
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="monospace">True</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="name">raw_profile</property>
-            <property name="title" translatable="yes">Profile Text</property>
-            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/src/tabs/controller/profile_modify_controller.cc
+++ b/src/tabs/controller/profile_modify_controller.cc
@@ -64,8 +64,6 @@ void ProfileModifyController::update_all_tables()
 
 void ProfileModifyController::handle_profile_changed()
 {
-  parser->saveChanges();
-
   // Find the new parsed profile from the list of profiles
   for (auto new_profile : parser->getProfileList()) {
     if (new_profile.name() == profile->name()) {
@@ -76,6 +74,9 @@ void ProfileModifyController::handle_profile_changed()
   // Update all the rows and tables
   update_all_tables();
   modify->update_profile_text();
+
+  // Decide whether the cancel/save buttons should be visible
+  modify->handle_apply_visible();
 }
 
 void ProfileModifyController::handle_file_rule_changed(const std::string &path)

--- a/src/tabs/controller/profile_modify_controller.cc
+++ b/src/tabs/controller/profile_modify_controller.cc
@@ -64,6 +64,8 @@ void ProfileModifyController::update_all_tables()
 
 void ProfileModifyController::handle_profile_changed()
 {
+  parser->saveChanges();
+
   // Find the new parsed profile from the list of profiles
   for (auto new_profile : parser->getProfileList()) {
     if (new_profile.name() == profile->name()) {

--- a/src/tabs/controller/profile_modify_controller.cc
+++ b/src/tabs/controller/profile_modify_controller.cc
@@ -142,6 +142,20 @@ void ProfileModifyController::handle_remove_rule(AppArmor::Tree::FileRule &old_r
   handle_profile_changed();
 }
 
+void ProfileModifyController::handle_cancel_called()
+{
+  parser->cancelChanges();
+  handle_profile_changed();
+}
+
+void ProfileModifyController::handle_apply_called()
+{
+  int re = parser->saveChanges();
+  if (re == 0) {
+    handle_profile_changed();
+  }
+}
+
 ProfileModifyController::ProfileModifyController(std::shared_ptr<AppArmor::Parser> parser, std::shared_ptr<AppArmor::Profile> profile)
   : parser{ parser },
     profile{ profile },
@@ -151,6 +165,10 @@ ProfileModifyController::ProfileModifyController(std::shared_ptr<AppArmor::Parse
 {
   auto change_fun = sigc::mem_fun(*this, &ProfileModifyController::handle_file_rule_changed);
   file_rule_record->set_change_func(change_fun);
+
+  auto handle_cancel_fun = sigc::mem_fun(*this, &ProfileModifyController::handle_cancel_called);
+  auto handle_apply_fun  = sigc::mem_fun(*this, &ProfileModifyController::handle_apply_called);
+  modify->connect_apply_buttons(handle_cancel_fun, handle_apply_fun);
 
   update_all_tables();
 }

--- a/src/tabs/controller/profile_modify_controller.h
+++ b/src/tabs/controller/profile_modify_controller.h
@@ -26,6 +26,8 @@ protected:
   void handle_file_rule_changed(const std::string &path);
   void handle_edit_rule(AppArmor::Tree::FileRule &old_rule, const AppArmor::Tree::FileRule &new_rule);
   void handle_remove_rule(AppArmor::Tree::FileRule &old_rule);
+  void handle_cancel_called();
+  void handle_apply_called();
 
 private:
   const std::vector<ColumnHeader> abstraction_col_names{ ColumnHeader("Abstraction", ColumnHeader::ColumnType::STRING) };

--- a/src/tabs/view/profile_modify.cc
+++ b/src/tabs/view/profile_modify.cc
@@ -26,9 +26,8 @@ std::shared_ptr<Gtk::TreeView> ProfileModifyImpl<AppArmorParser>::get_file_rule_
 }
 
 template<class AppArmorParser>
-void ProfileModifyImpl<AppArmorParser>::connect_apply_buttons(
-  const on_clicked_handler &cancel_button_handler,
-  const on_clicked_handler &apply_button_handler)
+void ProfileModifyImpl<AppArmorParser>::connect_apply_buttons(const on_clicked_handler &cancel_button_handler,
+                                                              const on_clicked_handler &apply_button_handler)
 {
   m_cancel_button->signal_clicked().connect(cancel_button_handler);
   m_apply_button->signal_clicked().connect(apply_button_handler);

--- a/src/tabs/view/profile_modify.cc
+++ b/src/tabs/view/profile_modify.cc
@@ -37,11 +37,7 @@ void ProfileModifyImpl<AppArmorParser>::connect_apply_buttons(
 template<class AppArmorParser>
 void ProfileModifyImpl<AppArmorParser>::handle_apply_visible()
 {
-  if(parser->hasChanges()) {
-    m_button_box->show();
-  } else {
-    m_button_box->hide();
-  }
+  m_button_reveal->set_reveal_child(parser->hasChanges());
 }
 
 template<class AppArmorParser>
@@ -61,7 +57,7 @@ ProfileModifyImpl<AppArmorParser>::ProfileModifyImpl(std::shared_ptr<AppArmorPar
     m_abstraction_view{ Common::get_widget<Gtk::TreeView>("m_abstraction_view", builder) },
     m_file_rule_view{ Common::get_widget<Gtk::TreeView>("m_file_rule_view", builder) },
     m_profile_text{ Common::get_widget<Gtk::TextView>("m_profile_text", builder) },
-    m_button_box{ Common::get_widget<Gtk::Box>("m_button_box", builder) },
+    m_button_reveal{ Common::get_widget<Gtk::Revealer>("m_button_reveal", builder) },
     m_cancel_button{ Common::get_widget<Gtk::Button>("m_cancel_button", builder) },
     m_apply_button{ Common::get_widget<Gtk::Button>("m_apply_button", builder) },
     parser{ parser }

--- a/src/tabs/view/profile_modify.cc
+++ b/src/tabs/view/profile_modify.cc
@@ -26,10 +26,19 @@ std::shared_ptr<Gtk::TreeView> ProfileModifyImpl<AppArmorParser>::get_file_rule_
 }
 
 template<class AppArmorParser>
+void ProfileModifyImpl<AppArmorParser>::handle_apply_visible()
+{
+  if(parser->hasChanges()) {
+    m_button_box->show();
+  } else {
+    m_button_box->hide();
+  }
+}
+
+template<class AppArmorParser>
 void ProfileModifyImpl<AppArmorParser>::update_profile_text()
 {
   const std::string profile_data = parser->operator std::string();
-
   m_profile_text->get_buffer()->set_text(profile_data);
 }
 
@@ -43,17 +52,23 @@ ProfileModifyImpl<AppArmorParser>::ProfileModifyImpl(std::shared_ptr<AppArmorPar
     m_abstraction_view{ Common::get_widget<Gtk::TreeView>("m_abstraction_view", builder) },
     m_file_rule_view{ Common::get_widget<Gtk::TreeView>("m_file_rule_view", builder) },
     m_profile_text{ Common::get_widget<Gtk::TextView>("m_profile_text", builder) },
+    m_button_box{ Common::get_widget<Gtk::Box>("m_button_box", builder) },
+    m_cancel_button{ Common::get_widget<Gtk::Button>("m_cancel_button", builder) },
+    m_apply_button{ Common::get_widget<Gtk::Button>("m_apply_button", builder) },
     parser{ parser }
 {
+  // Set the labels that show the Profile's name
   const auto &profile_name = profile->name();
   m_title_1->set_label(profile_name);
   m_title_2->set_label(profile_name);
   m_title_3->set_label(profile_name);
 
+  // Fill the textarea for the "Profile Text" section
   update_profile_text();
 
   this->add(*m_box);
   this->show_all();
+  handle_apply_visible();
 }
 
 template class ProfileModifyImpl<AppArmor::Parser>;

--- a/src/tabs/view/profile_modify.cc
+++ b/src/tabs/view/profile_modify.cc
@@ -26,6 +26,15 @@ std::shared_ptr<Gtk::TreeView> ProfileModifyImpl<AppArmorParser>::get_file_rule_
 }
 
 template<class AppArmorParser>
+void ProfileModifyImpl<AppArmorParser>::connect_apply_buttons(
+  const on_clicked_handler &cancel_button_handler,
+  const on_clicked_handler &apply_button_handler)
+{
+  m_cancel_button->signal_clicked().connect(cancel_button_handler);
+  m_apply_button->signal_clicked().connect(apply_button_handler);
+}
+
+template<class AppArmorParser>
 void ProfileModifyImpl<AppArmorParser>::handle_apply_visible()
 {
   if(parser->hasChanges()) {

--- a/src/tabs/view/profile_modify.h
+++ b/src/tabs/view/profile_modify.h
@@ -31,6 +31,10 @@ public:
   std::shared_ptr<Gtk::TreeView> get_abstraction_view();
   std::shared_ptr<Gtk::TreeView> get_file_rule_view();
 
+  typedef sigc::slot<void> on_clicked_handler;
+  void connect_apply_buttons(const on_clicked_handler &cancel_button_handler,
+                             const on_clicked_handler &apply_button_handler);
+
   // Decides whether the apply and cancel buttons should be visible
   void handle_apply_visible();
 

--- a/src/tabs/view/profile_modify.h
+++ b/src/tabs/view/profile_modify.h
@@ -31,6 +31,9 @@ public:
   std::shared_ptr<Gtk::TreeView> get_abstraction_view();
   std::shared_ptr<Gtk::TreeView> get_file_rule_view();
 
+  // Decides whether the apply and cancel buttons should be visible
+  void handle_apply_visible();
+
   // Overwrites the data in the Gtk::TreeView, which shows the file this profile is in.
   // Uses the data from AppArmor::Parser
   void update_profile_text();
@@ -49,6 +52,9 @@ private:
   std::shared_ptr<Gtk::TreeView> m_abstraction_view;
   std::shared_ptr<Gtk::TreeView> m_file_rule_view;
   std::shared_ptr<Gtk::TextView> m_profile_text;
+  std::shared_ptr<Gtk::Box> m_button_box;
+  std::shared_ptr<Gtk::Button> m_cancel_button;
+  std::shared_ptr<Gtk::Button> m_apply_button;
 
   // Fields used for reading and modifying the profile
   std::shared_ptr<AppArmorParser> parser;

--- a/src/tabs/view/profile_modify.h
+++ b/src/tabs/view/profile_modify.h
@@ -4,9 +4,9 @@
 #include <gtkmm/box.h>
 #include <gtkmm/builder.h>
 #include <gtkmm/button.h>
-#include <gtkmm/grid.h>
 #include <gtkmm/image.h>
 #include <gtkmm/label.h>
+#include <gtkmm/revealer.h>
 #include <gtkmm/scrolledwindow.h>
 #include <gtkmm/textview.h>
 #include <gtkmm/treeview.h>
@@ -56,7 +56,7 @@ private:
   std::shared_ptr<Gtk::TreeView> m_abstraction_view;
   std::shared_ptr<Gtk::TreeView> m_file_rule_view;
   std::shared_ptr<Gtk::TextView> m_profile_text;
-  std::shared_ptr<Gtk::Box> m_button_box;
+  std::shared_ptr<Gtk::Revealer> m_button_reveal;
   std::shared_ptr<Gtk::Button> m_cancel_button;
   std::shared_ptr<Gtk::Button> m_apply_button;
 

--- a/src/tabs/view/profile_modify.h
+++ b/src/tabs/view/profile_modify.h
@@ -32,8 +32,7 @@ public:
   std::shared_ptr<Gtk::TreeView> get_file_rule_view();
 
   typedef sigc::slot<void> on_clicked_handler;
-  void connect_apply_buttons(const on_clicked_handler &cancel_button_handler,
-                             const on_clicked_handler &apply_button_handler);
+  void connect_apply_buttons(const on_clicked_handler &cancel_button_handler, const on_clicked_handler &apply_button_handler);
 
   // Decides whether the apply and cancel buttons should be visible
   void handle_apply_visible();

--- a/src/threads/command_caller.cc
+++ b/src/threads/command_caller.cc
@@ -77,7 +77,7 @@ std::string CommandCaller::load_profile(CommandCaller *caller, const std::string
     return result.error;
   }
 
-  return "Success: loading porfile" + fileName;
+  return "Success: loading profile " + fileName;
 }
 
 std::string CommandCaller::disable_profile(CommandCaller *caller, const std::string &profileName)
@@ -89,7 +89,7 @@ std::string CommandCaller::disable_profile(CommandCaller *caller, const std::str
     return result.error;
   }
 
-  return "Success: disabling porfile" + profileName;
+  return "Success: disabling profile " + profileName;
 }
 
 std::string CommandCaller::locate_profile(const std::string &profile, const std::initializer_list<std::string> &possible_profile_locations)


### PR DESCRIPTION
This PR closes #56.

Now when a user makes changes to a profile, those changes are staged (but not automatically applied) by the _AppArmor::Parser_ class in [libappanvil](https://github.com/jack-ullery/libappanvil). Two buttons appear at the bottom of the screen that allow the user to either cancel the changes or apply them to the system.

Internally the logic for cancelling/applying changes is handled by libappanvil. Additionally, libappanvil can determine if there are any unsaved changes. In libappanvil I created a binary called "aa-replace" which saves a profile and loads it using "apparmor_parser".

I also added a GtkRevealer to automatically hide/show the cancel/apply buttons. These buttons should only be visible if there are staged changes to the profile.

I am considering creating a loading spinner, which will only show after the "Apply" button is pressed. Currently, it takes a few seconds for the pkexec prompt to pass and aa-replace to terminate. The user might be unsure whether the operation has completed successfully.