### PR TITLE
Added desktop entry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required (VERSION 3.16.3)
 
 project (appanvil)
+set(PROJECT_VERSION 0.2)
 
 #### Set Source Code #####
 set(PROJECT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
@@ -143,6 +144,8 @@ execute_process(
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+configure_file(${PROJECT_RESOURCE_DIR}/appanvil.desktop.in appanvil.desktop @ONLY)
+
 # This ensures that ${GLADE_RESOURCES} uses semicolons instead of newline characters as seperators
 string(REGEX REPLACE "\n" ";" GLADE_RESOURCES "${GLADE_RESOURCES}")
 string(REGEX REPLACE "resources/" "${PROJECT_RESOURCE_DIR}/" GLADE_RESOURCES "${GLADE_RESOURCES}")
@@ -204,6 +207,12 @@ add_subdirectory(test)
 install(
   TARGETS ${PROJECT_NAME}
   DESTINATION bin
+)
+
+#### Install desktop entry file ####
+install(
+  FILES ${CMAKE_BINARY_DIR}/appanvil.desktop
+  DESTINATION share/applications
 )
 
 set(CPACK_PACKAGE_NAME ${PROJECT_NAME})

--- a/resources/appanvil.desktop.in
+++ b/resources/appanvil.desktop.in
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Encoding=UTF-8
+Version=@PROJECT_VERSION@
+Type=Application
+Exec=@CMAKE_INSTALL_PREFIX@/bin/@PROJECT_NAME@
+Name=AppAnvil


### PR DESCRIPTION
Resolves issue #66.
Almost all linux distributions use .../share/applications for storing desktop entries. I also checked how other projects handle installing them and they all just hardcode this path. I don't think it would be an issue, but if there will be a need to improve it, I'll try to handle that.
I also added project version variable for tracking purposes.