### PR TITLE
Fix 'Load Profile' page

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(
   ${PROJECT_SOURCE_DIR}/tabs/controller/status_controller.cc
   ${PROJECT_SOURCE_DIR}/tabs/controller/profiles_controller.cc
   ${PROJECT_SOURCE_DIR}/tabs/controller/profile_modify_controller.cc
+  ${PROJECT_SOURCE_DIR}/tabs/controller/profile_loader_controller.cc
   ${PROJECT_SOURCE_DIR}/tabs/controller/processes_controller.cc
   ${PROJECT_SOURCE_DIR}/tabs/controller/logs_controller.cc
   ${PROJECT_SOURCE_DIR}/tabs/view/status.cc

--- a/src/tabs/controller/profile_loader_controller.cc
+++ b/src/tabs/controller/profile_loader_controller.cc
@@ -1,0 +1,45 @@
+#include "profile_loader_controller.h"
+#include "../../threads/command_caller.h"
+#include "../view/profile_loader.h"
+
+// TODO(apparmor): Need to make asynchronous eventually, there should be no direct calls to CommandCaller
+template<class ProfileLoaderTab>
+void ProfileLoaderController<ProfileLoaderTab>::on_confirm_clicked()
+{
+  // In production-code, this is a `Glib::RefPtr<Gio::File>`
+  auto file = fc->get_file();
+  
+  // If the file is not null, then attempt to load it as a new profiile
+  if (file) {
+  	auto filename = file->get_path(); 
+	  std::string short_filename = CommandCaller::load_profile(filename);
+
+    // TODO(apparmor): Add error handling, when the profile is not correctly formatted
+	  fc->set_label_text("Done");
+	}
+  else {
+	  fc->set_label_text("No profile selected!");
+  }
+}
+
+template<class ProfileLoaderTab>
+void ProfileLoaderController<ProfileLoaderTab>::clearLabel(){
+  fc->set_label_text("");
+}
+
+template<class ProfileLoaderTab>
+std::shared_ptr<ProfileLoaderTab> ProfileLoaderController<ProfileLoaderTab>::get_tab()
+{
+  return fc;
+}
+
+template<class ProfileLoaderTab>
+ProfileLoaderController<ProfileLoaderTab>::ProfileLoaderController()
+  : fc{new ProfileLoaderTab()}
+{
+  auto button_func = sigc::mem_fun(*this, &ProfileLoaderController::on_confirm_clicked);
+  fc->set_l_button_signal_handler(button_func);
+}
+
+// Used to avoid linker errors
+template class ProfileLoaderController<ProfileLoader>;

--- a/src/tabs/controller/profile_loader_controller.cc
+++ b/src/tabs/controller/profile_loader_controller.cc
@@ -8,22 +8,22 @@ void ProfileLoaderControllerImpl<ProfileLoaderTab>::on_confirm_clicked()
 {
   // In production-code, this is a `Glib::RefPtr<Gio::File>`
   auto file = fc->get_file();
-  
+
   // If the file is not null, then attempt to load it as a new profiile
   if (file) {
-  	auto filename = file->get_path(); 
-	  std::string short_filename = CommandCaller::load_profile(filename);
+    auto filename              = file->get_path();
+    std::string short_filename = CommandCaller::load_profile(filename);
 
     // TODO(apparmor): Add error handling, when the profile is not correctly formatted
-	  fc->set_label_text("Done");
-	}
-  else {
-	  fc->set_label_text("No profile selected!");
+    fc->set_label_text("Done");
+  } else {
+    fc->set_label_text("No profile selected!");
   }
 }
 
 template<class ProfileLoaderTab>
-void ProfileLoaderControllerImpl<ProfileLoaderTab>::clearLabel(){
+void ProfileLoaderControllerImpl<ProfileLoaderTab>::clearLabel()
+{
   fc->set_label_text("");
 }
 
@@ -35,7 +35,7 @@ std::shared_ptr<ProfileLoaderTab> ProfileLoaderControllerImpl<ProfileLoaderTab>:
 
 template<class ProfileLoaderTab>
 ProfileLoaderControllerImpl<ProfileLoaderTab>::ProfileLoaderControllerImpl()
-  : fc{new ProfileLoaderTab()}
+  : fc{ new ProfileLoaderTab() }
 {
   auto button_func = sigc::mem_fun(*this, &ProfileLoaderControllerImpl::on_confirm_clicked);
   fc->set_l_button_signal_handler(button_func);

--- a/src/tabs/controller/profile_loader_controller.cc
+++ b/src/tabs/controller/profile_loader_controller.cc
@@ -4,7 +4,7 @@
 
 // TODO(apparmor): Need to make asynchronous eventually, there should be no direct calls to CommandCaller
 template<class ProfileLoaderTab>
-void ProfileLoaderController<ProfileLoaderTab>::on_confirm_clicked()
+void ProfileLoaderControllerImpl<ProfileLoaderTab>::on_confirm_clicked()
 {
   // In production-code, this is a `Glib::RefPtr<Gio::File>`
   auto file = fc->get_file();
@@ -23,23 +23,23 @@ void ProfileLoaderController<ProfileLoaderTab>::on_confirm_clicked()
 }
 
 template<class ProfileLoaderTab>
-void ProfileLoaderController<ProfileLoaderTab>::clearLabel(){
+void ProfileLoaderControllerImpl<ProfileLoaderTab>::clearLabel(){
   fc->set_label_text("");
 }
 
 template<class ProfileLoaderTab>
-std::shared_ptr<ProfileLoaderTab> ProfileLoaderController<ProfileLoaderTab>::get_tab()
+std::shared_ptr<ProfileLoaderTab> ProfileLoaderControllerImpl<ProfileLoaderTab>::get_tab()
 {
   return fc;
 }
 
 template<class ProfileLoaderTab>
-ProfileLoaderController<ProfileLoaderTab>::ProfileLoaderController()
+ProfileLoaderControllerImpl<ProfileLoaderTab>::ProfileLoaderControllerImpl()
   : fc{new ProfileLoaderTab()}
 {
-  auto button_func = sigc::mem_fun(*this, &ProfileLoaderController::on_confirm_clicked);
+  auto button_func = sigc::mem_fun(*this, &ProfileLoaderControllerImpl::on_confirm_clicked);
   fc->set_l_button_signal_handler(button_func);
 }
 
 // Used to avoid linker errors
-template class ProfileLoaderController<ProfileLoader>;
+template class ProfileLoaderControllerImpl<ProfileLoader>;

--- a/src/tabs/controller/profile_loader_controller.h
+++ b/src/tabs/controller/profile_loader_controller.h
@@ -1,0 +1,40 @@
+#ifndef TABS_CONTROLLER_PROFILELOADER_CONTROLLER_H
+#define TABS_CONTROLLER_PROFILELOADER_CONTROLLER_H
+
+#include <gtkmm/builder.h>
+#include <gtkmm/comboboxtext.h>
+#include <gtkmm/enums.h>
+#include <gtkmm/filechooser.h>
+#include <gtkmm/filechooserdialog.h>
+#include <gtkmm/grid.h>
+#include <gtkmm/liststore.h>
+#include <gtkmm/notebook.h>
+#include <gtkmm/scrolledwindow.h>
+#include <gtkmm/searchentry.h>
+#include <gtkmm/textview.h>
+#include <gtkmm/treemodelcolumn.h>
+#include <gtkmm/treeview.h>
+#include <gtkmm/treeviewcolumn.h>
+#include <memory>
+#include <string>
+#include <vector>
+
+template<class ProfileLoaderTab>
+class ProfileLoaderController
+{
+  public:
+    ProfileLoaderController();
+    void clearLabel();
+
+    // Returns the Tab that this controller communicates with
+    std::shared_ptr<ProfileLoaderTab> get_tab();
+
+  protected:
+    // Signal handler
+    void on_confirm_clicked();
+
+  private:
+      std::shared_ptr<ProfileLoaderTab> fc;
+};
+
+#endif // TABS_CONTROLLER_PROFILELOADER_CONTROLLER_H

--- a/src/tabs/controller/profile_loader_controller.h
+++ b/src/tabs/controller/profile_loader_controller.h
@@ -24,19 +24,19 @@
 template<class ProfileLoaderTab>
 class ProfileLoaderControllerImpl
 {
-  public:
-    ProfileLoaderControllerImpl();
-    void clearLabel();
+public:
+  ProfileLoaderControllerImpl();
+  void clearLabel();
 
-    // Returns the Tab that this controller communicates with
-    std::shared_ptr<ProfileLoaderTab> get_tab();
+  // Returns the Tab that this controller communicates with
+  std::shared_ptr<ProfileLoaderTab> get_tab();
 
-  protected:
-    // Signal handler
-    void on_confirm_clicked();
+protected:
+  // Signal handler
+  void on_confirm_clicked();
 
-  private:
-      std::shared_ptr<ProfileLoaderTab> fc;
+private:
+  std::shared_ptr<ProfileLoaderTab> fc;
 };
 
 typedef ProfileLoaderControllerImpl<ProfileLoader> ProfileLoaderController;

--- a/src/tabs/controller/profile_loader_controller.h
+++ b/src/tabs/controller/profile_loader_controller.h
@@ -19,11 +19,13 @@
 #include <string>
 #include <vector>
 
+#include "../view/profile_loader.h"
+
 template<class ProfileLoaderTab>
-class ProfileLoaderController
+class ProfileLoaderControllerImpl
 {
   public:
-    ProfileLoaderController();
+    ProfileLoaderControllerImpl();
     void clearLabel();
 
     // Returns the Tab that this controller communicates with
@@ -36,5 +38,7 @@ class ProfileLoaderController
   private:
       std::shared_ptr<ProfileLoaderTab> fc;
 };
+
+typedef ProfileLoaderControllerImpl<ProfileLoader> ProfileLoaderController;
 
 #endif // TABS_CONTROLLER_PROFILELOADER_CONTROLLER_H

--- a/src/tabs/view/profiles.cc
+++ b/src/tabs/view/profiles.cc
@@ -3,7 +3,6 @@
 #include "../entries.h"
 #include "../model/status_column_record.h"
 #include "common.h"
-#include "profile_loader.h"
 #include "profile_modify.h"
 #include "status.h"
 
@@ -120,11 +119,11 @@ Profiles::Profiles()
     p_profile_info{ Common::get_widget<Gtk::Box>("p_profile_info", builder) },
     p_num_log_label{ Common::get_widget<Gtk::Label>("p_num_log_label", builder) },
     p_num_proc_label{ Common::get_widget<Gtk::Label>("p_num_proc_label", builder) },
-    loader{ std::make_unique<ProfileLoader>() },
+    loader_controller{ std::make_unique<ProfileLoaderController>() },
     profile_map{ CommandCaller::get_profiles() }
 {
   // Add tabs to the stack pane
-  p_stack->add(*loader, "loadProfile");
+  p_stack->add(*loader_controller->get_tab(), "loadProfile");
 
   // Configure the button used for loading a profile
   auto load_profile_toggle_fun = sigc::mem_fun(*this, &Profiles::handle_load_profile_toggle);

--- a/src/tabs/view/profiles.h
+++ b/src/tabs/view/profiles.h
@@ -2,7 +2,7 @@
 #define TABS_PROFILES_H
 
 #include "../controller/profile_modify_controller.h"
-#include "profile_loader.h"
+#include "../controller/profile_loader_controller.h"
 #include "profile_modify.h"
 #include "status.h"
 
@@ -51,7 +51,7 @@ private:
   std::unique_ptr<Gtk::Label> p_num_proc_label;
 
   // Additional pages, which are added to the stack
-  std::unique_ptr<ProfileLoader> loader;
+  std::unique_ptr<ProfileLoaderController> loader_controller;
   std::map<std::string, std::shared_ptr<ProfileModifyController>> modifiers;
 
   // Map of all known profiles

--- a/src/tabs/view/profiles.h
+++ b/src/tabs/view/profiles.h
@@ -1,8 +1,8 @@
 #ifndef TABS_PROFILES_H
 #define TABS_PROFILES_H
 
-#include "../controller/profile_modify_controller.h"
 #include "../controller/profile_loader_controller.h"
+#include "../controller/profile_modify_controller.h"
 #include "profile_modify.h"
 #include "status.h"
 


### PR DESCRIPTION
This fixes #54, by reintroducing _ProfileLoaderController_ which was deleted in de5f8b79e8433ea305ee88601ce5f0ad9947bf14.

There was also a minor fix to improve the linking for this controller.