### PR TITLE
Save manually edited profile

### DIFF
--- a/resources/profile_modify.glade
+++ b/resources/profile_modify.glade
@@ -238,7 +238,7 @@
                         <property name="margin-bottom">5</property>
                         <property name="orientation">vertical</property>
                         <child>
-                          <object class="GtkLabel" id="m_title_3">
+                          <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="tooltip-text" translatable="yes">The name of this profile</property>
@@ -247,7 +247,7 @@
                             <property name="margin-top">10</property>
                             <property name="margin-bottom">5</property>
                             <property name="hexpand">False</property>
-                            <property name="label" translatable="yes">Profile Name</property>
+                            <property name="label" translatable="yes">Profile Text</property>
                             <property name="selectable">True</property>
                             <attributes>
                               <attribute name="weight" value="bold"/>
@@ -262,31 +262,40 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkFrame">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="halign">start</property>
                             <property name="margin-top">10</property>
-                            <property name="margin-bottom">5</property>
-                            <property name="label" translatable="yes">Profile Text</property>
-                            <property name="selectable">True</property>
-                            <attributes>
-                              <attribute name="weight" value="normal"/>
-                              <attribute name="variant" value="title-caps"/>
-                              <attribute name="scale" value="1.2"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkTextView" id="m_profile_text">
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="monospace">True</property>
+                            <property name="label-xalign">0.009999999776482582</property>
+                            <property name="label-yalign">0</property>
+                            <child>
+                              <object class="GtkTextView" id="m_profile_text">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="left-margin">5</property>
+                                <property name="right-margin">5</property>
+                                <property name="top-margin">5</property>
+                                <property name="bottom-margin">5</property>
+                                <property name="monospace">True</property>
+                              </object>
+                            </child>
+                            <child type="label">
+                              <object class="GtkLabel" id="m_title_3">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="margin-start">10</property>
+                                <property name="margin-top">10</property>
+                                <property name="margin-bottom">5</property>
+                                <property name="label" translatable="yes">Profile Text</property>
+                                <property name="selectable">True</property>
+                                <attributes>
+                                  <attribute name="weight" value="normal"/>
+                                  <attribute name="variant" value="title-caps"/>
+                                  <attribute name="scale" value="1"/>
+                                </attributes>
+                              </object>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/resources/profile_modify.glade
+++ b/resources/profile_modify.glade
@@ -327,95 +327,6 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
-                <child>
-                  <object class="GtkRevealer" id="m_raw_text_apply_reveal">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="transition-type">slide-up</property>
-                    <property name="transition-duration">200</property>
-                    <property name="reveal-child">True</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-start">10</property>
-                        <property name="margin-end">10</property>
-                        <property name="margin-top">5</property>
-                        <property name="margin-bottom">5</property>
-                        <property name="spacing">5</property>
-                        <child>
-                          <object class="GtkButtonBox">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">end</property>
-                            <property name="hexpand">True</property>
-                            <child>
-                              <object class="GtkButton" id="m_raw_text_cancel_button">
-                                <property name="label" translatable="yes"> Cancel</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">True</property>
-                                <property name="image">dialog-cancel-2</property>
-                                <property name="always-show-image">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="m_raw_text_apply_button">
-                                <property name="label" translatable="yes"> Parse</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="receives-default">True</property>
-                                <property name="image">dialog-apply-2</property>
-                                <property name="always-show-image">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <style>
-                              <class name="linked"/>
-                            </style>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack-type">end</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="halign">start</property>
-                            <property name="hexpand">True</property>
-                            <property name="label" translatable="yes">There are unparsed manual changes </property>
-                            <attributes>
-                              <attribute name="style" value="italic"/>
-                            </attributes>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
               </object>
               <packing>
                 <property name="name">raw_profile</property>
@@ -428,6 +339,95 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkRevealer" id="m_raw_text_apply_reveal">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="transition-type">slide-up</property>
+            <property name="transition-duration">200</property>
+            <property name="reveal-child">True</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">10</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkButtonBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="hexpand">True</property>
+                    <child>
+                      <object class="GtkButton" id="m_raw_text_cancel_button">
+                        <property name="label" translatable="yes"> Cancel</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="image">dialog-cancel-2</property>
+                        <property name="always-show-image">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="m_raw_text_apply_button">
+                        <property name="label" translatable="yes"> Parse</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="image">dialog-apply-2</property>
+                        <property name="always-show-image">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <style>
+                      <class name="linked"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack-type">end</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
+                    <property name="label" translatable="yes">There are unparsed manual changes </property>
+                    <attributes>
+                      <attribute name="style" value="italic"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>

--- a/resources/profile_modify.glade
+++ b/resources/profile_modify.glade
@@ -2,6 +2,27 @@
 <!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkImage" id="dialog-apply-2">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">view-refresh</property>
+  </object>
+  <object class="GtkImage" id="dialog-cancel">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-cancel</property>
+  </object>
+  <object class="GtkImage" id="dialog-cancel-2">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-cancel</property>
+  </object>
+  <object class="GtkImage" id="dialog-ok">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">dialog-ok</property>
+    <property name="use-fallback">True</property>
+  </object>
   <object class="GtkBox" id="m_box">
     <property name="width-request">200</property>
     <property name="height-request">200</property>
@@ -265,7 +286,6 @@
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="vexpand">True</property>
-                        <property name="shadow-type">in</property>
                         <property name="min-content-width">0</property>
                         <property name="min-content-height">0</property>
                         <property name="overlay-scrolling">False</property>
@@ -307,6 +327,95 @@
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkRevealer" id="m_raw_text_apply_reveal">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="transition-type">slide-up</property>
+                    <property name="transition-duration">200</property>
+                    <property name="reveal-child">True</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-end">10</property>
+                        <property name="margin-top">5</property>
+                        <property name="margin-bottom">5</property>
+                        <property name="spacing">5</property>
+                        <child>
+                          <object class="GtkButtonBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <child>
+                              <object class="GtkButton" id="m_raw_text_cancel_button">
+                                <property name="label" translatable="yes"> Cancel</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="image">dialog-cancel-2</property>
+                                <property name="always-show-image">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="m_raw_text_apply_button">
+                                <property name="label" translatable="yes"> Parse</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="image">dialog-apply-2</property>
+                                <property name="always-show-image">True</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                            <style>
+                              <class name="linked"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="pack-type">end</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">There are unparsed manual changes </property>
+                            <attributes>
+                              <attribute name="style" value="italic"/>
+                            </attributes>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="name">raw_profile</property>
@@ -345,11 +454,11 @@
                     <property name="hexpand">True</property>
                     <child>
                       <object class="GtkButton" id="m_cancel_button">
-                        <property name="label">gtk-cancel</property>
+                        <property name="label" translatable="yes"> Cancel</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
-                        <property name="use-stock">True</property>
+                        <property name="image">dialog-cancel</property>
                         <property name="always-show-image">True</property>
                       </object>
                       <packing>
@@ -360,11 +469,11 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="m_apply_button">
-                        <property name="label">gtk-apply</property>
+                        <property name="label" translatable="yes"> Apply</property>
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">True</property>
-                        <property name="use-stock">True</property>
+                        <property name="image">dialog-ok</property>
                         <property name="always-show-image">True</property>
                       </object>
                       <packing>
@@ -390,7 +499,7 @@
                     <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="hexpand">True</property>
-                    <property name="label" translatable="yes">There are unsaved changes </property>
+                    <property name="label" translatable="yes">There are unapplied changes </property>
                     <attributes>
                       <attribute name="style" value="italic"/>
                     </attributes>

--- a/resources/profile_modify.glade
+++ b/resources/profile_modify.glade
@@ -219,93 +219,93 @@
               </packing>
             </child>
             <child>
-              <object class="GtkScrolledWindow">
+              <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="hexpand">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">10</property>
+                <property name="margin-end">15</property>
+                <property name="margin-bottom">5</property>
                 <property name="vexpand">True</property>
-                <property name="hscrollbar-policy">never</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkViewport">
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="tooltip-text" translatable="yes">The name of this profile</property>
+                    <property name="halign">start</property>
+                    <property name="valign">start</property>
+                    <property name="margin-end">10</property>
+                    <property name="margin-top">10</property>
+                    <property name="margin-bottom">5</property>
+                    <property name="label" translatable="yes">Profile Text</property>
+                    <property name="selectable">True</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                      <attribute name="variant" value="title-caps"/>
+                      <attribute name="scale" value="1.3999999999999999"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">10</property>
+                    <property name="vexpand">True</property>
+                    <property name="label-xalign">0.009999999776482582</property>
+                    <property name="label-yalign">0</property>
+                    <property name="shadow-type">in</property>
                     <child>
-                      <object class="GtkBox">
+                      <object class="GtkScrolledWindow">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-start">10</property>
-                        <property name="margin-end">15</property>
-                        <property name="margin-bottom">5</property>
-                        <property name="orientation">vertical</property>
+                        <property name="can-focus">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="shadow-type">in</property>
+                        <property name="min-content-width">0</property>
+                        <property name="min-content-height">0</property>
+                        <property name="overlay-scrolling">False</property>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkTextView" id="m_profile_text">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="tooltip-text" translatable="yes">The name of this profile</property>
-                            <property name="halign">start</property>
-                            <property name="margin-end">10</property>
-                            <property name="margin-top">10</property>
-                            <property name="margin-bottom">5</property>
-                            <property name="hexpand">False</property>
-                            <property name="label" translatable="yes">Profile Text</property>
-                            <property name="selectable">True</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                              <attribute name="variant" value="title-caps"/>
-                              <attribute name="scale" value="1.3999999999999999"/>
-                            </attributes>
+                            <property name="can-focus">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="left-margin">5</property>
+                            <property name="right-margin">5</property>
+                            <property name="top-margin">5</property>
+                            <property name="bottom-margin">5</property>
+                            <property name="monospace">True</property>
                           </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkFrame">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-top">10</property>
-                            <property name="label-xalign">0.009999999776482582</property>
-                            <property name="label-yalign">0</property>
-                            <child>
-                              <object class="GtkTextView" id="m_profile_text">
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="left-margin">5</property>
-                                <property name="right-margin">5</property>
-                                <property name="top-margin">5</property>
-                                <property name="bottom-margin">5</property>
-                                <property name="monospace">True</property>
-                              </object>
-                            </child>
-                            <child type="label">
-                              <object class="GtkLabel" id="m_title_3">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="margin-start">10</property>
-                                <property name="margin-top">10</property>
-                                <property name="margin-bottom">5</property>
-                                <property name="label" translatable="yes">Profile Text</property>
-                                <property name="selectable">True</property>
-                                <attributes>
-                                  <attribute name="weight" value="normal"/>
-                                  <attribute name="variant" value="title-caps"/>
-                                  <attribute name="scale" value="1"/>
-                                </attributes>
-                              </object>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
                         </child>
                       </object>
                     </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="m_title_3">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin-start">10</property>
+                        <property name="margin-top">10</property>
+                        <property name="margin-bottom">5</property>
+                        <property name="label" translatable="yes">Profile Text</property>
+                        <property name="selectable">True</property>
+                        <attributes>
+                          <attribute name="weight" value="normal"/>
+                          <attribute name="variant" value="title-caps"/>
+                          <attribute name="scale" value="1"/>
+                        </attributes>
+                      </object>
+                    </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>

--- a/src/tabs/controller/profile_modify_controller.cc
+++ b/src/tabs/controller/profile_modify_controller.cc
@@ -171,5 +171,8 @@ ProfileModifyController::ProfileModifyController(const std::shared_ptr<AppArmor:
   auto handle_apply_fun  = sigc::mem_fun(*this, &ProfileModifyController::handle_apply_called);
   modify->connect_apply_buttons(handle_cancel_fun, handle_apply_fun);
 
+  auto handle_prof_fun = sigc::mem_fun(*this, &ProfileModifyController::handle_profile_changed);
+  modify->connect_handle_profile_changed(handle_prof_fun);
+
   update_all_tables();
 }

--- a/src/tabs/view/profile_modify.cc
+++ b/src/tabs/view/profile_modify.cc
@@ -47,6 +47,16 @@ void ProfileModifyImpl<AppArmorParser>::update_profile_text()
 }
 
 template<class AppArmorParser>
+void ProfileModifyImpl<AppArmorParser>::handle_profile_text_change()
+{
+  const std::string old_profile_data = parser->operator std::string();
+  const std::string new_profile_data = m_profile_text->get_buffer()->get_text();
+
+  const bool changed = (old_profile_data != new_profile_data);
+  m_raw_text_apply_reveal->set_reveal_child(changed);
+}
+
+template<class AppArmorParser>
 ProfileModifyImpl<AppArmorParser>::ProfileModifyImpl(std::shared_ptr<AppArmorParser> parser,
                                                      const std::shared_ptr<AppArmor::Profile> &profile)
   : builder{ Gtk::Builder::create_from_resource("/resources/profile_modify.glade") },
@@ -60,6 +70,9 @@ ProfileModifyImpl<AppArmorParser>::ProfileModifyImpl(std::shared_ptr<AppArmorPar
     m_button_reveal{ Common::get_widget<Gtk::Revealer>("m_button_reveal", builder) },
     m_cancel_button{ Common::get_widget<Gtk::Button>("m_cancel_button", builder) },
     m_apply_button{ Common::get_widget<Gtk::Button>("m_apply_button", builder) },
+    m_raw_text_apply_reveal{Common::get_widget<Gtk::Revealer>("m_raw_text_apply_reveal", builder)},
+    m_raw_text_cancel_button{Common::get_widget<Gtk::Button>("m_raw_text_cancel_button", builder)},
+    m_raw_text_apply_button{Common::get_widget<Gtk::Button>("m_raw_text_apply_button", builder)},
     parser{ parser }
 {
   // Set the labels that show the Profile's name
@@ -70,6 +83,11 @@ ProfileModifyImpl<AppArmorParser>::ProfileModifyImpl(std::shared_ptr<AppArmorPar
 
   // Fill the textarea for the "Profile Text" section
   update_profile_text();
+  handle_profile_text_change();
+
+  // Handle the changes in m_profile_text
+  auto handle_text_change = sigc::mem_fun(*this, &ProfileModifyImpl<AppArmorParser>::handle_profile_text_change);
+  m_profile_text->get_buffer()->signal_changed().connect(handle_text_change);
 
   this->add(*m_box);
   this->show_all();

--- a/src/tabs/view/profile_modify.cc
+++ b/src/tabs/view/profile_modify.cc
@@ -25,8 +25,7 @@ std::shared_ptr<Gtk::TreeView> ProfileModifyImpl<AppArmorParser>::get_file_rule_
 }
 
 template<class AppArmorParser>
-void ProfileModifyImpl<AppArmorParser>::connect_apply_buttons(const void_func &cancel_button_handler,
-                                                              const void_func &apply_button_handler)
+void ProfileModifyImpl<AppArmorParser>::connect_apply_buttons(const void_func &cancel_button_handler, const void_func &apply_button_handler)
 {
   m_cancel_button->signal_clicked().connect(cancel_button_handler);
   m_apply_button->signal_clicked().connect(apply_button_handler);
@@ -85,9 +84,9 @@ ProfileModifyImpl<AppArmorParser>::ProfileModifyImpl(std::shared_ptr<AppArmorPar
     m_button_reveal{ Common::get_widget<Gtk::Revealer>("m_button_reveal", builder) },
     m_cancel_button{ Common::get_widget<Gtk::Button>("m_cancel_button", builder) },
     m_apply_button{ Common::get_widget<Gtk::Button>("m_apply_button", builder) },
-    m_raw_text_apply_reveal{Common::get_widget<Gtk::Revealer>("m_raw_text_apply_reveal", builder)},
-    m_raw_text_cancel_button{Common::get_widget<Gtk::Button>("m_raw_text_cancel_button", builder)},
-    m_raw_text_apply_button{Common::get_widget<Gtk::Button>("m_raw_text_apply_button", builder)},
+    m_raw_text_apply_reveal{ Common::get_widget<Gtk::Revealer>("m_raw_text_apply_reveal", builder) },
+    m_raw_text_cancel_button{ Common::get_widget<Gtk::Button>("m_raw_text_cancel_button", builder) },
+    m_raw_text_apply_button{ Common::get_widget<Gtk::Button>("m_raw_text_apply_button", builder) },
     parser{ parser }
 {
   // Set the labels that show the Profile's name

--- a/src/tabs/view/profile_modify.h
+++ b/src/tabs/view/profile_modify.h
@@ -75,7 +75,7 @@ private:
   std::shared_ptr<Gtk::Button> m_raw_text_apply_button;
 
   // Function that will be called if parser is updated internally
-  void_func handle_apparmor_parser_changed = [](){};
+  void_func handle_apparmor_parser_changed = []() {};
 
   // Fields used for reading and modifying the profile
   std::shared_ptr<AppArmorParser> parser;

--- a/src/tabs/view/profile_modify.h
+++ b/src/tabs/view/profile_modify.h
@@ -31,8 +31,12 @@ public:
   std::shared_ptr<Gtk::TreeView> get_abstraction_view();
   std::shared_ptr<Gtk::TreeView> get_file_rule_view();
 
-  typedef sigc::slot<void> on_clicked_handler;
-  void connect_apply_buttons(const on_clicked_handler &cancel_button_handler, const on_clicked_handler &apply_button_handler);
+  typedef sigc::slot<void> void_func;
+  void connect_apply_buttons(const void_func &cancel_button_handler, const void_func &apply_button_handler);
+
+  // Connect function which will be called when the AppArmorParser is updated internally
+  // This happends if a user manuallt edits the profile in the "Profile Text" section
+  void connect_handle_profile_changed(const void_func &parser_handler);
 
   // Decides whether the apply and cancel buttons should be visible
   void handle_apply_visible();
@@ -43,7 +47,11 @@ public:
 
 protected:
   // Called when the buffer in 'm_profile_text' is changed
-  void handle_profile_text_change();
+  void handle_raw_profile_text_change();
+
+  // Called when 'm_raw_text_apply_button' is pressed
+  // Parses the text buffer in 'm_profile_text', attempting to apply it to the profile
+  void apply_raw_profile_text_change();
 
 private:
   // GUI Builder to parse UI from xml file
@@ -65,6 +73,9 @@ private:
   std::shared_ptr<Gtk::Revealer> m_raw_text_apply_reveal;
   std::shared_ptr<Gtk::Button> m_raw_text_cancel_button;
   std::shared_ptr<Gtk::Button> m_raw_text_apply_button;
+
+  // Function that will be called if parser is updated internally
+  void_func handle_apparmor_parser_changed = [](){};
 
   // Fields used for reading and modifying the profile
   std::shared_ptr<AppArmorParser> parser;

--- a/src/tabs/view/profile_modify.h
+++ b/src/tabs/view/profile_modify.h
@@ -41,6 +41,10 @@ public:
   // Uses the data from AppArmor::Parser
   void update_profile_text();
 
+protected:
+  // Called when the buffer in 'm_profile_text' is changed
+  void handle_profile_text_change();
+
 private:
   // GUI Builder to parse UI from xml file
   Glib::RefPtr<Gtk::Builder> builder;
@@ -58,6 +62,9 @@ private:
   std::shared_ptr<Gtk::Revealer> m_button_reveal;
   std::shared_ptr<Gtk::Button> m_cancel_button;
   std::shared_ptr<Gtk::Button> m_apply_button;
+  std::shared_ptr<Gtk::Revealer> m_raw_text_apply_reveal;
+  std::shared_ptr<Gtk::Button> m_raw_text_cancel_button;
+  std::shared_ptr<Gtk::Button> m_raw_text_apply_button;
 
   // Fields used for reading and modifying the profile
   std::shared_ptr<AppArmorParser> parser;


### PR DESCRIPTION
This change allows the user to manually edit, parse, and apply changes to a Profile, by using the "Profile Text" section on the "Profile Modify" page. They can do this by pressing the "Parse" button which will appear if there were any manual changes entered into the text area. Afterwards, they much select "Apply" to save and apply the modified profile to the system (like they would if changing the profile through another screen).

This two-step process might be a little unintuitive, but it was the best solution I could come up with given technical constraints. The main problem I had was: when should changes made in this editor be parsed? Should I reparse them continuously every time a key is pressed (maybe waiting for a timeout), or should I allow the user to manually choose? If I choose the former approach, then changes might be deleted (or not saved) if the user accidentally makes a syntax error when writing the profile. Even though the latter approach introduces more friction, it should hopefully be more transparent to the experienced user.