### PR TITLE
Add warning message when AppArmor is not enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ set(
   ${PROJECT_SOURCE_DIR}/tabs/controller/profile_loader_controller.cc
   ${PROJECT_SOURCE_DIR}/tabs/controller/processes_controller.cc
   ${PROJECT_SOURCE_DIR}/tabs/controller/logs_controller.cc
+  ${PROJECT_SOURCE_DIR}/tabs/view/apparmor_not_installed.cc
   ${PROJECT_SOURCE_DIR}/tabs/view/status.cc
   ${PROJECT_SOURCE_DIR}/tabs/view/profiles.cc
   ${PROJECT_SOURCE_DIR}/tabs/view/processes.cc

--- a/resources/ui/apparmor_not_installed.glade
+++ b/resources/ui/apparmor_not_installed.glade
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkMessageDialog" id="apparmor_not_installed">
+    <property name="can-focus">False</property>
+    <property name="type-hint">dialog</property>
+    <property name="message-type">error</property>
+    <property name="text" translatable="yes">&lt;b&gt;AppArmor is not running&lt;/b&gt;</property>
+    <property name="use-markup">True</property>
+    <property name="secondary-text" translatable="yes">AppArmor is not running on this system (according to &lt;b&gt;aa-enabled&lt;/b&gt;).
+
+Please install AppArmor before running this application.</property>
+    <property name="secondary-use-markup">True</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="button_box">
+            <property name="can-focus">False</property>
+            <property name="homogeneous">True</property>
+            <property name="layout-style">end</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/resources/ui/resources.gresource.xml
+++ b/resources/ui/resources.gresource.xml
@@ -9,6 +9,7 @@
     <file preprocess="xml-stripblanks">profile.glade</file>
     <file preprocess="xml-stripblanks">status.glade</file>
     <file preprocess="xml-stripblanks">log.glade</file>
+    <file preprocess="xml-stripblanks">apparmor_not_installed.glade</file>
 
     <file preprocess="xml-stripblanks">modal/help.glade</file>
     <file preprocess="xml-stripblanks">modal/load_profile.glade</file>

--- a/src/main.cc
+++ b/src/main.cc
@@ -26,8 +26,7 @@ int main()
   register_resource_bundle();
 
   // If AppArmor is not enabled, send an error message
-  if(!CommandCaller::get_enabled())
-  {
+  if (!CommandCaller::get_enabled()) {
     auto dialog = AppArmorNotInstalled::get_dialog();
     return app->run(*dialog);
   }

--- a/src/main.cc
+++ b/src/main.cc
@@ -1,4 +1,6 @@
 #include "main_window.h"
+#include "tabs/view/apparmor_not_installed.h"
+#include "threads/command_caller.h"
 
 // NOLINTNEXTLINE(bugprone-suspicious-include)
 #include "resource.autogen.c"
@@ -22,6 +24,13 @@ int main()
 {
   auto app = Gtk::Application::create("com.github.jack-ullery");
   register_resource_bundle();
+
+  // If AppArmor is not enabled, send an error message
+  if(!CommandCaller::get_enabled())
+  {
+    auto dialog = AppArmorNotInstalled::get_dialog();
+    return app->run(*dialog);
+  }
 
   // Shows the window and returns when it is closed.
   MainWindow win;

--- a/src/tabs/view/apparmor_not_installed.cc
+++ b/src/tabs/view/apparmor_not_installed.cc
@@ -4,7 +4,7 @@
 std::unique_ptr<Gtk::MessageDialog> AppArmorNotInstalled::get_dialog()
 {
   auto builder = Gtk::Builder::create_from_resource("/apparmor_not_installed.glade");
-  auto dialog = Common::get_widget<Gtk::MessageDialog>("apparmor_not_installed", builder);
+  auto dialog  = Common::get_widget<Gtk::MessageDialog>("apparmor_not_installed", builder);
 
   return dialog;
 }

--- a/src/tabs/view/apparmor_not_installed.cc
+++ b/src/tabs/view/apparmor_not_installed.cc
@@ -1,0 +1,10 @@
+#include "apparmor_not_installed.h"
+#include "common.h"
+
+std::unique_ptr<Gtk::MessageDialog> AppArmorNotInstalled::get_dialog()
+{
+  auto builder = Gtk::Builder::create_from_resource("/apparmor_not_installed.glade");
+  auto dialog = Common::get_widget<Gtk::MessageDialog>("apparmor_not_installed", builder);
+
+  return dialog;
+}

--- a/src/tabs/view/apparmor_not_installed.h
+++ b/src/tabs/view/apparmor_not_installed.h
@@ -1,0 +1,15 @@
+#ifndef TABS_VIEW_APPARMOR_NOT_INSTALLED_H
+#define TABS_VIEW_APPARMOR_NOT_INSTALLED_H
+
+#include <gtkmm/messagedialog.h>
+
+class AppArmorNotInstalled
+{
+public:
+  /**
+   * @brief Builds and shows the "AppArmor Not Installed" error message.
+   */
+  static std::unique_ptr<Gtk::MessageDialog> get_dialog();
+};
+
+#endif // TABS_VIEW_APPARMOR_NOT_INSTALLED_H

--- a/src/threads/command_caller.cc
+++ b/src/threads/command_caller.cc
@@ -173,7 +173,7 @@ std::string CommandCaller::execute_change(CommandCaller *caller,
 bool CommandCaller::get_enabled(CommandCaller *caller) noexcept
 {
   std::vector<std::string> command = { "aa-enabled", "-q" };
-  auto result = caller->call_command(command);
+  auto result                      = caller->call_command(command);
   return (result.exit_status == 0);
 }
 

--- a/src/threads/command_caller.cc
+++ b/src/threads/command_caller.cc
@@ -214,6 +214,12 @@ std::string CommandCaller::execute_change(const std::string &profile, const std:
   return execute_change(&caller, profile, old_status, new_status);
 }
 
+bool CommandCaller::get_enabled() noexcept
+{
+  CommandCaller caller;
+  return get_enabled(&caller);
+}
+
 // TODO(multiple-locations) handle different abstractions in multiple profile locations
 std::vector<std::string> CommandCaller::get_abstractions(const std::string &path)
 {

--- a/src/threads/command_caller.cc
+++ b/src/threads/command_caller.cc
@@ -170,6 +170,13 @@ std::string CommandCaller::execute_change(CommandCaller *caller,
   return " Changed '" + profile + "' from " + old_status + " to " + new_status;
 }
 
+bool CommandCaller::get_enabled(CommandCaller *caller) noexcept
+{
+  std::vector<std::string> command = { "aa-enabled", "-q" };
+  auto result = caller->call_command(command);
+  return (result.exit_status == 0);
+}
+
 // Static public methods
 std::pair<std::string, bool> CommandCaller::get_status() noexcept
 {

--- a/src/threads/command_caller.h
+++ b/src/threads/command_caller.h
@@ -70,7 +70,7 @@ public:
 
   /**
    * @brief Returns true if AppArmor is enabled on the system
-   * 
+   *
    * @return true, if `aa-enabled -q` has exit code 0
    * @return false, if `aa-enabled -q` does not have exit code 0
    */

--- a/src/threads/command_caller.h
+++ b/src/threads/command_caller.h
@@ -69,6 +69,14 @@ public:
   static std::pair<std::string, bool> get_logs(const std::string &checkpoint_filepath) noexcept;
 
   /**
+   * @brief Returns true if AppArmor is enabled on the system
+   * 
+   * @return true, if `aa-enabled -q` has exit code 0
+   * @return false, if `aa-enabled -q` does not have exit code 0
+   */
+  static bool get_enabled() noexcept;
+
+  /**
    * @brief Change the status of a profile
    *
    * @details
@@ -123,6 +131,7 @@ protected:
                                     const std::string &profile,
                                     const std::string &old_status,
                                     const std::string &new_status);
+  static bool get_enabled(CommandCaller *caller) noexcept;
 
 #ifdef TESTS_ENABLED
   FRIEND_TEST(CommandCallerTest, TEST_UNCONF);
@@ -136,6 +145,8 @@ protected:
   FRIEND_TEST(CommandCallerTest, TEST_CHANGE_STATUS_CE);
   FRIEND_TEST(CommandCallerTest, TEST_CHANGE_STATUS_EC_SUCCESS);
   FRIEND_TEST(CommandCallerTest, TEST_CHANGE_STATUS_CE_FAIL);
+  FRIEND_TEST(CommandCallerTest, TEST_GET_AA_ENABLED_SUCCESS);
+  FRIEND_TEST(CommandCallerTest, TEST_GET_AA_ENABLED_FAIL);
 #endif
 };
 

--- a/test/src/threads/command_caller.cc
+++ b/test/src/threads/command_caller.cc
@@ -112,3 +112,19 @@ TEST_F(CommandCallerTest, TEST_CHANGE_STATUS_CE_FAIL)
   EXPECT_TRUE(output.find(tester.result_error.error) != std::string::npos)
     << "returned string should contain the error returned from `call_command`.";
 }
+
+TEST_F(CommandCallerTest, TEST_GET_AA_ENABLED_FAIL)
+{
+  EXPECT_CALL(tester, call_command(_)).WillOnce(Return(tester.result_error));
+
+  bool aa_enabled = CommandCallerMock::get_enabled(&tester);
+  ASSERT_FALSE(aa_enabled);
+}
+
+TEST_F(CommandCallerTest, TEST_GET_AA_ENABLED_SUCCESS)
+{
+  EXPECT_CALL(tester, call_command(_)).WillOnce(Return(tester.result_success));
+
+  bool aa_enabled = CommandCallerMock::get_enabled(&tester);
+  ASSERT_TRUE(aa_enabled);
+}


### PR DESCRIPTION
Solves #85 by using `aa-enabled` to see if AppArmor is running. 

If `aa-enabled` exits with a non-zero status code, we then create a dialog box informing the user that AppArmor is not installed. This check is run in `main.cc`, before the MainWindow is built.