### PR TITLE
Update CMake test config

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -111,17 +111,29 @@ if(${GTEST_FOUND} AND ${GMOCK_FOUND})
   cmake_policy(SET CMP0110 NEW)
 
   # Discover the tests
-  gtest_add_tests(
-    TARGET ${PROJECT_NAME}
-    SOURCES ${APPANVIL_TEST_SOURCES}
+  #gtest_add_tests(
+  #TARGET ${PROJECT_NAME}
+  #SOURCES ${APPANVIL_TEST_SOURCES}
+  #WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
+  #TEST_PREFIX "[appanvil] "
+  #TEST_LIST ADDED_TESTS_1
+  #)
+  gtest_discover_tests(
+    ${PROJECT_NAME}
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
-    TEST_PREFIX "[appanvil] "
+    TEST_PREFIX "[appanvil]"
     TEST_LIST ADDED_TESTS_1
   )
 
-  gtest_add_tests(
-    TARGET ${PROJECT_NAME}
-    SOURCES ${AA_CALLER_TEST_SOURCES}
+  #gtest_add_tests(
+  #TARGET ${PROJECT_NAME}
+  #SOURCES ${AA_CALLER_TEST_SOURCES}
+  #WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/aa-caller"
+  #TEST_PREFIX "[aa-caller] "
+  #TEST_LIST ADDED_TESTS_2
+  #)
+  gtest_discover_tests(
+    ${PROJECT_NAME}
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/aa-caller"
     TEST_PREFIX "[aa-caller] "
     TEST_LIST ADDED_TESTS_2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -110,14 +110,6 @@ if(${GTEST_FOUND} AND ${GMOCK_FOUND})
   # To allow whitespace in test names
   cmake_policy(SET CMP0110 NEW)
 
-  # Discover the tests
-  #gtest_add_tests(
-  #TARGET ${PROJECT_NAME}
-  #SOURCES ${APPANVIL_TEST_SOURCES}
-  #WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
-  #TEST_PREFIX "[appanvil] "
-  #TEST_LIST ADDED_TESTS_1
-  #)
   gtest_discover_tests(
     ${PROJECT_NAME}
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/src"
@@ -125,13 +117,6 @@ if(${GTEST_FOUND} AND ${GMOCK_FOUND})
     TEST_LIST ADDED_TESTS_1
   )
 
-  #gtest_add_tests(
-  #TARGET ${PROJECT_NAME}
-  #SOURCES ${AA_CALLER_TEST_SOURCES}
-  #WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/aa-caller"
-  #TEST_PREFIX "[aa-caller] "
-  #TEST_LIST ADDED_TESTS_2
-  #)
   gtest_discover_tests(
     ${PROJECT_NAME}
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/aa-caller"


### PR DESCRIPTION
The `gtest_add_tests` macro is very old and breaks when building on newer versions of CMake (in my case cmake 3.31.4-1 on ArchLinux). 
![image](https://github.com/user-attachments/assets/75723a3c-8c14-4c39-a338-766efdc8350a)
Switching to `gtest_discover_tests` and omitting the `SOURCES` option works, but whichever is causing the issue is unclear. 
By the way, doing this seems to automatically ignore the unused tests, which is a plus in my book.
I'm pasting the results from running `make test` to prove that no regression is introduced. 
**Before:**
```
95% tests passed, 72 tests failed out of 1584
```
**After:**
```
99% tests passed, 2 tests failed out of 1514
```