### PR TITLE
Only update TreeView when data is changed

### DIFF
--- a/src/tabs/controller/profiles_controller.cc
+++ b/src/tabs/controller/profiles_controller.cc
@@ -109,22 +109,31 @@ void ProfilesController<ProfilesTab, Database, Adapter>::add_data_to_record(cons
   Json::Value root     = StatusController<ProfilesTab>::parse_JSON(data);
   Json::Value profiles = root["profiles"];
 
+  // Parse each object in the "profiles" field of the json,
+  //   and attempt to add each tuple to this db
+  bool changed = false;
   for (auto profile = profiles.begin(); profile != profiles.end(); profile++) {
     auto profile_name = profile.key().asString();
     auto status       = profiles.get(profile_name, UNKNOWN_STR).asString();
-    adapter.put_data(profile_name, status);
+    changed |= adapter.put_data(profile_name, status);
   }
 
-  refresh();
+  // Refilter the table, but only if tuples were added
+  if(changed)
+  {
+    refresh();
+  }
 }
 
 template<class ProfilesTab, class Database, class Adapter>
 void ProfilesController<ProfilesTab, Database, Adapter>::refresh()
 {
+  // Update the label in the profiles section
   std::stringstream label;
   label << " " << adapter.get_col_record()->filter_rows() << " matching profiles";
-
   prof->set_status_label_text(label.str());
+
+  // Check if any row was selected/unselected
   handle_profile_selected();
 }
 

--- a/src/tabs/controller/profiles_controller.cc
+++ b/src/tabs/controller/profiles_controller.cc
@@ -119,8 +119,7 @@ void ProfilesController<ProfilesTab, Database, Adapter>::add_data_to_record(cons
   }
 
   // Refilter the table, but only if tuples were added
-  if(changed)
-  {
+  if (changed) {
     refresh();
   }
 }

--- a/src/tabs/model/profile_adapter.h
+++ b/src/tabs/model/profile_adapter.h
@@ -18,7 +18,10 @@ public:
   // Initializes the database adapter
   ProfileAdapter(std::shared_ptr<Database> db, const std::shared_ptr<Gtk::TreeView> &view);
 
-  void put_data(const std::string &profile_name, const std::string &status);
+  // Inserts the tuple into the database
+  // Returns true if any data was added
+  // Returns false if this tuple already exists in the database
+  bool put_data(const std::string &profile_name, const std::string &status);
 
   void set_profile_status_change_func(const StatusColumnRecord::change_function_type &fun);
 


### PR DESCRIPTION
This fixes #99 by only updating the TreeView when there are new/different profiles.

Since this doesn't affect the other Processes/Logs screen, all I had to do was modify the ProfilesController class to be more careful when it calls _refresh()_.